### PR TITLE
feat: add messaging tags for sns, sqs and kinesis

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
@@ -208,6 +208,11 @@ class BotocoreInstrumentor(BaseInstrumentor):
                 attributes["rpc.request.payload"] = limit_string_size(json.dumps(call_context.params, default=str))
             elif call_context.service == "kinesis" and (call_context.operation == "PutRecord" or call_context.operation == "PutRecords"):
                 call_context.span_kind = SpanKind.PRODUCER
+                streamName = call_context.params.get("StreamName")
+                if streamName:
+                    attributes[SpanAttributes.MESSAGING_SYSTEM] = "aws.kinesis"
+                    attributes[SpanAttributes.MESSAGING_DESTINATION] = streamName
+
                 attributes["rpc.request.payload"] = limit_string_size(json.dumps(call_context.params, default=str))
             elif call_context.service == "sqs" and (call_context.operation == "SendMessageBatch" or call_context.operation == "SendMessage"):
                 call_context.span_kind = SpanKind.PRODUCER


### PR DESCRIPTION
# Description

Adds messaging attributes so that we can view them in service map

![image](https://github.com/coralogix/opentelemetry-python-contrib/assets/22289110/50d9a028-0473-4e2c-a6b1-85e2b0730c72)

Fixes ES-265