### PR TITLE
ES-539: avoid crash if list is provided to botocore instrumentation

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/lmbd.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/extensions/lmbd.py
@@ -96,7 +96,7 @@ class _OpInvoke(_LambdaOperation):
             inject(headers)
             payload["headers"] = headers
             call_context.params["Payload"] = json.dumps(payload)
-        except ValueError:
+        except (ValueError, AttributeError):
             pass
 
 ################################################################################


### PR DESCRIPTION
# Description

Avoid instrumentation crash if user provides a list to the `invoke` method from `botocore`.

Example:
```python
self.client.invoke(
    FunctionName=function_name,
    InvocationType="RequestResponse",
​    Payload=json.dumps(['test']),
)
```

The examples we found related to this library always show the usage of dictionaries as `Payload` but nothing is preventing the user from doing this.

This change will not support creating a proper trace but will not crash user application.