### PR TITLE
[ES-556] Fix missing context propagation for SQS messages

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/__init__.py
@@ -87,33 +87,26 @@ from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import unwrap
 from opentelemetry.metrics import MeterProvider, get_meter_provider
 from opentelemetry.propagate import get_global_textmap
-from opentelemetry.propagators import textmap
 from opentelemetry.semconv.resource import ResourceAttributes
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace import (
     Span,
     SpanKind,
-    Link,
     Tracer,
     TracerProvider,
     get_tracer,
     get_tracer_provider,
-    set_span_in_context,
     use_span,
 )
-from opentelemetry.trace.propagation import get_current_span
 from opentelemetry.trace.status import Status, StatusCode
 from opentelemetry.trace.span import (
-    INVALID_SPAN_ID,
     format_trace_id,
     format_span_id,
 )
-import json
-import typing
-import base64
-#import traceback
 
-#tracemalloc.start(25)
+from opentelemetry.instrumentation.aws_lambda.coralogix.logger import cx_exception
+from opentelemetry.instrumentation.aws_lambda.coralogix import instrumentor as cxinstrumentor
+from opentelemetry.instrumentation.aws_lambda.coralogix import context as cx_context
 
 logger = logging.getLogger(__name__)
 
@@ -125,7 +118,7 @@ OTEL_INSTRUMENTATION_AWS_LAMBDA_FLUSH_TIMEOUT = (
 )
 
 
-def _default_event_context_extractor(args: Any) -> Context:
+def _default_event_context_extractor(lambda_event: Any) -> Context:
     """Default way of extracting the context from the Lambda Event.
 
     Assumes the Lambda Event is a map with the headers under the 'headers' key.
@@ -143,25 +136,6 @@ def _default_event_context_extractor(args: Any) -> Context:
     Returns:
         A Context with configuration found in the event.
     """
-
-    lambda_event = args[0]
-
-    #print("lambda_event")
-    #print("args")
-    #print(args)
-    #print("context")
-    #print(json.dumps(args[1], indent=4, sort_keys=True, default=str))
-    context = args[1]
-    try:
-        #print(json.dumps(context.client_context.custom, indent=4, sort_keys=True, default=str))
-
-        return get_global_textmap().extract(context.client_context.custom)
-    except Exception as ex:
-        #print(traceback.format_exc())
-        #print("exception")
-        #print(ex)
-        pass
-
     headers = None
     try:
         headers = lambda_event["headers"]
@@ -178,7 +152,7 @@ def _determine_parent_context(
     lambda_event: Any,
     event_context_extractor: Callable[[Any], Context],
 ) -> Context:
-    """Determine the upstream context for the current Lambda invocation.
+    """Determine the parent context for the current Lambda invocation.
 
     See more:
     https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/instrumentation/aws-lambda.md#determining-the-parent-of-a-span
@@ -309,7 +283,7 @@ def _set_api_gateway_v2_proxy_attributes(
 def _instrument(
     wrapped_module_name,
     wrapped_function_name,
-    flush_timeout: int,
+    flush_timeout,
     event_context_extractor: Callable[[Any], Context],
     tracer_provider: TracerProvider = None,
     meter_provider: MeterProvider = None,
@@ -325,9 +299,10 @@ def _instrument(
 
         lambda_event = args[0]
 
-        parent_context = _determine_parent_context(
-            args,
+        parent_context = cx_context.determine_parent_context(
+            lambda_event,
             event_context_extractor,
+            _determine_parent_context,  # type: ignore[arg-type]
         )
 
         try:
@@ -346,112 +321,91 @@ def _instrument(
                 # https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-content-structure.html
                 # https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html
                 span_kind = SpanKind.CONSUMER
-
             else:
                 span_kind = SpanKind.SERVER
         except (IndexError, KeyError, TypeError):
             span_kind = SpanKind.SERVER
-      
-        tracer = get_tracer(__name__, __version__, tracer_provider)
+
+        tracer = get_tracer(
+            __name__,
+            __version__,
+            tracer_provider,
+            schema_url="https://opentelemetry.io/schemas/1.11.0",
+        )
+
         token = context_api.attach(parent_context)
 
+        # Get coralogix span and context
+        cx_instrumentor = cxinstrumentor.get_cx_instrumentor(
+            tracer,
+            parent_context,
+            lambda_event,
+            orig_handler_name
+        )
+
+        trigger_span = None
         trigger_context = None
-        triggerSpan = None
+        if cx_instrumentor is not None:
+            try:
+                trigger_span, trigger_context = cx_instrumentor.before_run()
+            except Exception as e:  # pylint: disable=broad-except
+                cx_exception(e, "Error creating trigger span")
 
-        apiGwSpan = None
+        if trigger_span is not None:
+            trigger_span.set_attribute("cx.internal.span.role", "trigger")
+     
+        if trigger_context is not None:
+            invocation_parent_context = trigger_context
+        else:
+            invocation_parent_context = parent_context
+
         try:
-            # If the request came from an API Gateway, extract http attributes from the event
-            # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/instrumentation/aws-lambda.md#api-gateway
-            # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-server-semantic-conventions
-            if isinstance(lambda_event, dict) and lambda_event.get(
-                "requestContext"
-            ):
-                span_name = orig_handler_name
-                if lambda_event.get("resource"):
-                    span_name = lambda_event.get("resource")
-                if lambda_event.get("requestContext") and lambda_event["requestContext"].get("http"):
-                    span_name = lambda_event["requestContext"]["http"].get("path")
-                
-                apiGwSpan = tracer.start_span(span_name, context=parent_context, kind=SpanKind.CLIENT)
-                if lambda_event.get("version") == "2.0":
-                    apiGwSpan.set_attribute("faas.trigger.type", "Api Gateway Rest")
-                else:
-                    apiGwSpan.set_attribute("faas.trigger.type", "Api Gateway HTTP")
-                
-                apiGwSpan.set_attribute(SpanAttributes.FAAS_TRIGGER, "http")
+            invocation_span = tracer.start_span(
+                    name=orig_handler_name,
+                    context=invocation_parent_context,
+                    kind=span_kind,
+                )
+            invocation_span.set_attribute("cx.internal.span.role", "invocation")
+        except Exception as e:  # pylint: disable=broad-except
+            cx_exception(e, "Error creating invocation span")
 
-                triggerSpan = apiGwSpan
-                trigger_context = set_span_in_context(apiGwSpan)
-        except Exception as ex:
-            pass
-        # S3 trigger new span and request attributes
-        s3TriggerSpan = None
         try:
-            if lambda_event["Records"][0]["eventSource"] in {
-                "aws:s3",
-            }:
-                span_name = orig_handler_name
-                if lambda_event["Records"][0].get("eventName"):
-                    span_name = lambda_event["Records"][0].get("eventName")
+            _sendEarlySpans(
+                flush_timeout,
+                tracer,
+                tracer_provider,
+                meter_provider,
+                trigger_parent_context=parent_context,
+                trigger_span=trigger_span,
+                invocation_parent_context=invocation_parent_context,
+                invocation_span=invocation_span,
+            )
+        except Exception as e:  # pylint: disable=broad-except
+            cx_exception(e, "Error sending early spans")
 
-                s3TriggerSpan = tracer.start_span(span_name, context=parent_context, kind=SpanKind.PRODUCER)
-                s3TriggerSpan.set_attribute(SpanAttributes.FAAS_TRIGGER, "datasource")
-                s3TriggerSpan.set_attribute("faas.trigger.type", "S3")
-
-                triggerSpan = s3TriggerSpan
-                trigger_context = set_span_in_context(s3TriggerSpan)
-
-                if lambda_event["Records"][0].get("s3"):
-                    s3TriggerSpan.set_attribute(
-                        "rpc.request.body",
-                        limit_string_size(json.dumps(lambda_event["Records"][0].get("s3"))),
-                    )    
-        except Exception as ex:
-            pass
-
-        sqsTriggerSpan = None
         try:
-            if lambda_event["Records"][0]["eventSource"] in {
-                "aws:sqs",
-            }:
-                links = []
-                queue_url = ""
-                for record in lambda_event["Records"]:
-                    if queue_url == "":
-                        queue_url = record.get("eventSourceARN")
-
-                    attributes = record.get("messageAttributes")
-                    if attributes is not None:
-                        ctx = get_global_textmap().extract(carrier=attributes, getter=SQSGetter())
-                        span_ctx = get_current_span(ctx).get_span_context()
-                        if span_ctx.span_id != INVALID_SPAN_ID:
-                            links.append(Link(span_ctx))
-
-                span_name = orig_handler_name
-                sqsTriggerSpan = tracer.start_span(span_name, context=parent_context, kind=SpanKind.CONSUMER, links=links)
-                sqsTriggerSpan.set_attribute(SpanAttributes.FAAS_TRIGGER, "pubsub")
-                sqsTriggerSpan.set_attribute("faas.trigger.type", "SQS")
-                sqsTriggerSpan.set_attribute(SpanAttributes.MESSAGING_SYSTEM, "aws.sqs")
-                sqsTriggerSpan.set_attribute(SpanAttributes.MESSAGING_URL, queue_url)
-
-                try:
-                    # Example queue_url: arn:aws:sqs:us-east-1:123456789012:my_queue_name
-                    sqsTriggerSpan.set_attribute(SpanAttributes.MESSAGING_DESTINATION, queue_url.split(":")[-1])
-                except IndexError:
-                    pass
-                
-                triggerSpan = sqsTriggerSpan
-                trigger_context = set_span_in_context(sqsTriggerSpan)
-
-                if lambda_event["Records"][0].get("body"):
-                    sqsTriggerSpan.set_attribute(
-                        "rpc.request.body",
-                        limit_string_size(lambda_event["Records"][0].get("body")),
+            with use_span(
+                span=invocation_span,
+                end_on_exit=True,
+            ) as span:
+                if span.is_recording():
+                    lambda_context = args[1]
+                    # NOTE: The specs mention an exception here, allowing the
+                    # `SpanAttributes.CLOUD_RESOURCE_ID` attribute to be set as a span
+                    # attribute instead of a resource attribute.
+                    #
+                    # See more:
+                    # https://github.com/open-telemetry/semantic-conventions/blob/main/docs/faas/aws-lambda.md#resource-detector
+                    span.set_attribute(
+                        SpanAttributes.CLOUD_RESOURCE_ID,
+                        lambda_context.invoked_function_arn,
                     )
                     span.set_attribute(
                         SpanAttributes.FAAS_INVOCATION_ID,
                         lambda_context.aws_request_id,
                     )
+
+                    cxinstrumentor.set_cx_span_attributes(span, lambda_context)
 
                     # NOTE: `cloud.account.id` can be parsed from the ARN as the fifth item when splitting on `:`
                     #
@@ -464,6 +418,15 @@ def _instrument(
                         ResourceAttributes.CLOUD_ACCOUNT_ID,
                         account_id,
                     )
+
+                exception = None
+                result = None
+                try:
+                    result = call_wrapped(*args, **kwargs)
+                except Exception as exc:  # pylint: disable=W0703
+                    exception = exc
+                    span.set_status(Status(StatusCode.ERROR))
+                    span.record_exception(exception)
 
                 # If the request came from an API Gateway, extract http attributes from the event
                 # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/instrumentation/aws-lambda.md#api-gateway
@@ -487,397 +450,52 @@ def _instrument(
                             SpanAttributes.HTTP_STATUS_CODE,
                             result.get("statusCode"),
                         )
-        except Exception as ex:
-            pass
-
-
-        snsTriggerSpan = None
-        try:
-            if lambda_event["Records"][0]["EventSource"] == "aws:sns":
-                links = []
-                queue_url = ""
-                for record in lambda_event["Records"]:
-                    if record.get("Sns") is None:
-                        continue
-
-                    if queue_url == "":
-                        queue_url = record.get("Sns").get("TopicArn")
-
-                    attributes = record.get("Sns").get("MessageAttributes")
-                    if attributes is not None:
-                        ctx = get_global_textmap().extract(carrier=attributes, getter=SNSGetter())
-                        span_ctx = get_current_span(ctx).get_span_context()
-                        if span_ctx.span_id != INVALID_SPAN_ID:
-                            links.append(Link(span_ctx))
-
-                span_kind = SpanKind.INTERNAL
-                span_name = orig_handler_name
-                snsTriggerSpan = tracer.start_span(span_name, context=parent_context, kind=SpanKind.CONSUMER, links=links)
-                snsTriggerSpan.set_attribute(SpanAttributes.FAAS_TRIGGER, "pubsub")
-                snsTriggerSpan.set_attribute("faas.trigger.type", "SNS")
-                snsTriggerSpan.set_attribute(SpanAttributes.MESSAGING_SYSTEM, "aws.sns")
-                snsTriggerSpan.set_attribute(SpanAttributes.MESSAGING_URL, queue_url)
-
-                try:
-                    # Example queue_url: arn:aws:sns:us-east-1:123456789012:my_topic_name
-                    snsTriggerSpan.set_attribute(SpanAttributes.MESSAGING_DESTINATION, queue_url.split(":")[-1])
-                except IndexError:
-                    pass
-
-                triggerSpan = snsTriggerSpan
-                trigger_context = set_span_in_context(snsTriggerSpan)
-
-                if lambda_event["Records"][0]["Sns"] and lambda_event["Records"][0]["Sns"].get("Message"):
-                    snsTriggerSpan.set_attribute(
-                        "rpc.request.body",
-                        limit_string_size(lambda_event["Records"][0]["Sns"].get("Message")),
-                    )    
-        except Exception as ex:
-            pass
-
-        kinesisTriggerSpan = None
-        try:
-            if lambda_event["Records"][0]["eventSource"] == "aws:kinesis":
-                links = []
-                queue_url = ""
-
-                for record in lambda_event["Records"]:
-                    if record.get("kinesis") is None:
-                        continue
-
-                    if queue_url == "":
-                        queue_url = record.get("eventSourceARN")
-
-                    data = record["kinesis"].get("data")
-                    if data is not None:
-                        decoded_bytes = base64.b64decode(data)
-                        decoded_string = decoded_bytes.decode('utf-8')
-                        data = json.loads(decoded_string)
-                        ctx = get_global_textmap().extract(carrier=data.get("_context"))
-                        span_ctx = get_current_span(ctx).get_span_context()
-                        if span_ctx.span_id != INVALID_SPAN_ID:
-                            links.append(Link(span_ctx))
-                span_kind = SpanKind.INTERNAL
-                span_name = orig_handler_name
-                kinesisTriggerSpan = tracer.start_span(span_name, context=parent_context, kind=SpanKind.CONSUMER, links=links)
-                kinesisTriggerSpan.set_attribute(SpanAttributes.FAAS_TRIGGER, "pubsub")
-                kinesisTriggerSpan.set_attribute("faas.trigger.type", "Kinesis")
-                kinesisTriggerSpan.set_attribute(SpanAttributes.MESSAGING_SYSTEM, "aws.kinesis")
-                kinesisTriggerSpan.set_attribute(SpanAttributes.MESSAGING_URL, queue_url)
-
-                try:
-                    # Example queue_url: arn:aws:kinesis:us-east-1:123456789012:stream/my_stream_name
-                    kinesisTriggerSpan.set_attribute(SpanAttributes.MESSAGING_DESTINATION, queue_url.split("/")[-1])
-                except IndexError:
-                    pass
-
-                triggerSpan = kinesisTriggerSpan
-                trigger_context = set_span_in_context(kinesisTriggerSpan)
-
-                if lambda_event["Records"][0]["kinesis"] and lambda_event["Records"][0]["kinesis"].get("data"):
-                    decoded_bytes = base64.b64decode(lambda_event["Records"][0]["kinesis"].get("data"))
-                    decoded_string = decoded_bytes.decode('utf-8')
-                    data = json.loads(decoded_string)
-
-                    kinesisTriggerSpan.set_attribute(
-                        "rpc.request.body",
-                        limit_string_size(data),
-                    )
-        except Exception as e:
-            pass
-
-        dynamoTriggerSpan = None
-        try:
-            if lambda_event["Records"][0]["eventSource"] == "aws:dynamodb":
-                span_name = orig_handler_name
-                if lambda_event["Records"][0].get("eventName"):
-                    span_name = lambda_event["Records"][0].get("eventName")
-
-                dynamoTriggerSpan = tracer.start_span(span_name, context=parent_context, kind=SpanKind.PRODUCER)
-                dynamoTriggerSpan.set_attribute(SpanAttributes.FAAS_TRIGGER, "datasource")
-                dynamoTriggerSpan.set_attribute("faas.trigger.type", "Dynamo DB")
-
-                triggerSpan = dynamoTriggerSpan
-                trigger_context = set_span_in_context(dynamoTriggerSpan)
-
-                if lambda_event["Records"][0].get("dynamodb"):
-                    dynamoTriggerSpan.set_attribute(
-                        "rpc.request.body",
-                        limit_string_size(json.dumps(lambda_event["Records"][0].get("dynamodb"))),
-                    )    
-        except Exception as ex:
-            pass
-
-        cognitoTriggerSpan = None
-        try:
-            if lambda_event["eventType"] == "SyncTrigger":
-                span_name = orig_handler_name
-                if lambda_event.get("eventType"):
-                    span_name = lambda_event.get("eventType") 
-
-                cognitoTriggerSpan = tracer.start_span(span_name, context=parent_context, kind=SpanKind.PRODUCER)
-                cognitoTriggerSpan.set_attribute(SpanAttributes.FAAS_TRIGGER, "datasource")
-                cognitoTriggerSpan.set_attribute("faas.trigger.type", "Cognito")
-
-                triggerSpan = cognitoTriggerSpan
-                trigger_context = set_span_in_context(cognitoTriggerSpan)
-
-                if lambda_event["datasetRecords"]:
-                    cognitoTriggerSpan.set_attribute(
-                        "rpc.request.body",
-                        limit_string_size(json.dumps(lambda_event["datasetRecords"])),
-                    )
-        except Exception as ex:
-            pass
-
-        eventBridgeTriggerSpan = None
-        try:
-            if type(lambda_event) is dict and lambda_event.get("source") is not None and type(lambda_event.get("source")) is str:
-                span_name = 'EventBridge event'
-                if lambda_event.get("detail-type") is not None:
-                    span_name = lambda_event.get("detail-type")
-
-                links = []
-                if lambda_event.get("detail") is not None and lambda_event["detail"].get("_context") is not None:
-                    ctx = get_global_textmap().extract(carrier=lambda_event["detail"].get("_context"))
-                    span_ctx = get_current_span(ctx).get_span_context()
-                    if span_ctx.span_id != INVALID_SPAN_ID:
-                        links.append(Link(span_ctx))
-
-                eventBridgeTriggerSpan = tracer.start_span(span_name, context=parent_context, kind=SpanKind.CONSUMER, links=links)
-                eventBridgeTriggerSpan.set_attribute(SpanAttributes.FAAS_TRIGGER, "pubsub")
-                eventBridgeTriggerSpan.set_attribute("faas.trigger.type", "EventBridge")
-                eventBridgeTriggerSpan.set_attribute("aws.event.bridge.trigger.source", lambda_event.get("source"))
-
-                triggerSpan = eventBridgeTriggerSpan
-                trigger_context = set_span_in_context(eventBridgeTriggerSpan)
-
-                eventBridgeTriggerSpan.set_attribute(
-                    "rpc.request.body",
-                    limit_string_size(json.dumps(lambda_event)),
-                )
-        except Exception as ex:
-            pass
-
-        context_api.detach(token)
-
-        if triggerSpan is not None:
-            triggerSpan.set_attribute("cx.internal.span.role", "trigger")
- 
-        try:
-            if trigger_context is not None:
-                invocation_parent_context = trigger_context
-            else:
-                invocation_parent_context = parent_context
-
-            invocationSpan = tracer.start_span(
-                name=orig_handler_name,
-                context=invocation_parent_context,
-                kind=span_kind,
-            )
-            invocationSpan.set_attribute("cx.internal.span.role", "invocation")
-            try:
-                _sendEarlySpans(
-                    flush_timeout,
-                    tracer,
-                    tracer_provider,
-                    meter_provider,
-                    trigger_parent_context=parent_context,
-                    trigger_span=triggerSpan,
-                    invocation_parent_context=invocation_parent_context,
-                    invocation_span=invocationSpan,
-                )
-            except Exception as ex:
-                pass
-
-            with use_span(
-                span=invocationSpan,
-                end_on_exit=True,
-            ) as span:
-                if span.is_recording():
-                    lambda_context = args[1]
-                    # NOTE: The specs mention an exception here, allowing the
-                    # `ResourceAttributes.FAAS_ID` attribute to be set as a span
-                    # attribute instead of a resource attribute.
-                    #
-                    # See more:
-                    # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/faas.md#example
-                    span.set_attribute(
-                        ResourceAttributes.FAAS_ID,
-                        lambda_context.invoked_function_arn,
-                    )
-                    span.set_attribute(
-                        SpanAttributes.FAAS_EXECUTION,
-                        lambda_context.aws_request_id,
-                    )
-
-                exception = None
-                result = None
-                try:
-                    result = call_wrapped(*args, **kwargs)
-                except Exception as exc:  # pylint: disable=W0703
-                    exception = exc
-                    span.set_status(Status(StatusCode.ERROR))
-                    span.record_exception(exception)
-
-                # If the request came from an AlambdaPI Gateway, extract http attributes from the event
-                # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/instrumentation/aws-lambda.md#api-gateway
-                # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-server-semantic-conventions
-                try:
-                    if lambda_event and apiGwSpan is not None and lambda_event.get("requestContext"):
-                        apiGwSpan.set_attribute(SpanAttributes.FAAS_TRIGGER, "http")
-
-                        if lambda_event.get("version") == "2.0":
-                            _set_api_gateway_v2_proxy_attributes(lambda_event, apiGwSpan)
-                        else:
-                            _set_api_gateway_v1_proxy_attributes(lambda_event, apiGwSpan)
-
-                        if isinstance(result, dict) and result.get("statusCode"):
-                            apiGwSpan.set_attribute(
-                                SpanAttributes.HTTP_STATUS_CODE,
-                                result.get("statusCode"),
-                            )
-                        if isinstance(result, dict) and result.get("body"):
-                            apiGwSpan.set_attribute(
-                                "http.response.body",
-                                limit_string_size(result.get("body")),
-                            )
-                        if lambda_event.get("headers"):
-                            for key, value in lambda_event.get("headers").items():
-                                apiGwSpan.set_attribute("http.request.header." + key.lower().replace("-", "_"), value)
-
-                        if lambda_event["requestContext"].get("domainName") and lambda_event["requestContext"].get("http") and lambda_event["requestContext"].get("http").get("path"):
-                            apiGwSpan.set_attribute(
-                                SpanAttributes.HTTP_URL,
-                                lambda_event["requestContext"].get("domainName") + lambda_event["requestContext"].get("http").get("path")
-                            )
-                    try:
-                        if lambda_event["Records"][0]["eventSource"] == "aws:sqs":
-                            span.set_attribute(SpanAttributes.FAAS_TRIGGER, "pubsub")
-                            span.set_attribute("messaging.message",
-                                            limit_string_size(lambda_event["Records"][0].get("body")))
-                    except Exception as ex:
-                        #print(traceback.format_exc())
-                        #print("exception")
-                        #print(ex)
-                        pass
-                except Exception as ex:
-                    # TODO check why we get exception
-                    # logger.error(
-                    #    "TracerProvider was missing `force_flush` method. This is necessary in case of a Lambda freeze and would exist in the OTel SDK implementation."
-                    # )
-                    pass
-
-                # S3 trigger response attributes
-                if lambda_event and s3TriggerSpan is not None:
-                    try:
-                        if isinstance(result, dict) and result.get("statusCode"):
-                            s3TriggerSpan.set_attribute(
-                                SpanAttributes.HTTP_STATUS_CODE,
-                                result.get("statusCode"),
-                            )
-                        if isinstance(result, dict) and result.get("body"):
-                            s3TriggerSpan.set_attribute(
-                                "rpc.response.body",
-                                limit_string_size(result.get("body")),
-                            )
-                    except Exception:
-                        pass
-
-                # SQS trigger response attributes
-                if lambda_event and sqsTriggerSpan is not None:
-                    try:
-                        if isinstance(result, dict) and result.get("statusCode"):
-                            sqsTriggerSpan.set_attribute(
-                                SpanAttributes.HTTP_STATUS_CODE,
-                                result.get("statusCode"),
-                            )
-                        if isinstance(result, dict) and result.get("body"):
-                            sqsTriggerSpan.set_attribute(
-                                "rpc.response.body",
-                                limit_string_size(result.get("body")),
-                            )
-                    except Exception:
-                        pass
-
-                if lambda_event and snsTriggerSpan is not None:
-                    try:
-                        if isinstance(result, dict) and result.get("statusCode"):
-                            snsTriggerSpan.set_attribute(
-                                SpanAttributes.HTTP_STATUS_CODE,
-                                result.get("statusCode"),
-                            )
-                        if isinstance(result, dict) and result.get("body"):
-                            snsTriggerSpan.set_attribute(
-                                "rpc.response.body",
-                                limit_string_size(result.get("body")),
-                            )
-                    except Exception:
-                        pass
-
-                if lambda_event and kinesisTriggerSpan is not None:
-                    try:
-                        if isinstance(result, dict) and result.get("ResponseMetadata"):
-                            if result["ResponseMetadata"].get("HTTPStatusCode"):
-                                kinesisTriggerSpan.set_attribute(
-                                    SpanAttributes.HTTP_STATUS_CODE,
-                                    result["ResponseMetadata"]["HTTPStatusCode"],
-                                )
-                    except Exception:
-                        pass
-
-                if lambda_event and dynamoTriggerSpan is not None:
-                    try:
-                        if isinstance(result, dict) and result.get("statusCode"):
-                            dynamoTriggerSpan.set_attribute(
-                                SpanAttributes.HTTP_STATUS_CODE,
-                                result.get("statusCode"),
-                            )
-                        if isinstance(result, dict) and result.get("body"):
-                            dynamoTriggerSpan.set_attribute(
-                                "rpc.response.body",
-                                limit_string_size(result.get("body")),
-                            )
-                    except Exception:
-                        pass
-
-                if lambda_event and cognitoTriggerSpan is not None:
-                    try:
-                        if isinstance(result, dict) and result.get("statusCode"):
-                            cognitoTriggerSpan.set_attribute(
-                                SpanAttributes.HTTP_STATUS_CODE,
-                                result.get("statusCode"),
-                            )
-                        if isinstance(result, dict) and result.get("body"):
-                            cognitoTriggerSpan.set_attribute(
-                                "rpc.response.body",
-                                limit_string_size(result.get("body")),
-                            )
-                    except Exception:
-                        pass
-                
-                if lambda_event and eventBridgeTriggerSpan is not None:
-                    try:
-                        if isinstance(result, dict) and result.get("statusCode"):
-                            eventBridgeTriggerSpan.set_attribute(
-                                SpanAttributes.HTTP_STATUS_CODE,
-                                result.get("statusCode"),
-                            )
-                        if isinstance(result, dict) and result.get("body"):
-                            eventBridgeTriggerSpan.set_attribute(
-                                "rpc.response.body",
-                                limit_string_size(result.get("body")),
-                            )
-                    except Exception:
-                        pass
-
-        except Exception as e:
-            raise e
-
         finally:
-            if triggerSpan is not None:
-                triggerSpan.end()
+            context_api.detach(token)
+            if cx_instrumentor is not None:
+                try:
+                    cx_instrumentor.after_run(
+                        result,  # type: ignore[arg-type]
+                    )
+                except Exception as e:  # pylint: disable=broad-except
+                    cx_exception(e, "Error after run")
+
+            if trigger_span is not None:
+                try:
+                    trigger_span.end()
+                except Exception as e:  # pylint: disable=broad-except
+                    cx_exception(e, "Error ending trigger span")
             _flush(flush_timeout, tracer_provider, meter_provider)
+
+        now = time.time()
+        _tracer_provider = tracer_provider or get_tracer_provider()
+        if hasattr(_tracer_provider, "force_flush"):
+            try:
+                # NOTE: `force_flush` before function quit in case of Lambda freeze.
+                _tracer_provider.force_flush(flush_timeout)
+            except Exception:  # pylint: disable=broad-except
+                logger.exception("TracerProvider failed to flush traces")
+        else:
+            logger.warning(
+                "TracerProvider was missing `force_flush` method. This is necessary in case of a Lambda freeze and would exist in the OTel SDK implementation."
+            )
+
+        _meter_provider = meter_provider or get_meter_provider()
+        if hasattr(_meter_provider, "force_flush"):
+            rem = flush_timeout - (time.time() - now) * 1000
+            if rem > 0:
+                try:
+                    # NOTE: `force_flush` before function quit in case of Lambda freeze.
+                    _meter_provider.force_flush(rem)
+                except Exception:  # pylint: disable=broad-except
+                    logger.exception("MeterProvider failed to flush metrics")
+        else:
+            logger.warning(
+                "MeterProvider was missing `force_flush` method. This is necessary in case of a Lambda freeze and would exist in the OTel SDK implementation."
+            )
+
+        if exception is not None:
+            raise exception.with_traceback(exception.__traceback__)
 
         return result
 
@@ -1043,53 +661,4 @@ class AwsLambdaInstrumentor(BaseInstrumentor):
         )
 
 
-class SQSGetter():
-    def get(
-        self, carrier: typing.Mapping[str, textmap.CarrierValT], key: str
-    ) -> typing.Optional[typing.List[str]]:
-        """Getter implementation to retrieve a value from a dictionary.
 
-        Args:
-            carrier: dictionary in which to get value
-            key: the key used to get the value
-        Returns:
-            A list with a single string with the value if it exists, else None.
-        """
-        val = carrier.get(key, None)
-        if val is None:
-            return None
-        if val.get("stringValue") is not None:
-            return [val.get("stringValue")]
-        return None
-
-    def keys(
-        self, carrier: typing.Mapping[str, textmap.CarrierValT]
-    ) -> typing.List[str]:
-        """Keys implementation that returns all keys from a dictionary."""
-        return list(carrier.keys())
-
-
-class SNSGetter():
-    def get(
-        self, carrier: typing.Mapping[str, textmap.CarrierValT], key: str
-    ) -> typing.Optional[typing.List[str]]:
-        """Getter implementation to retrieve a value from a dictionary.
-
-        Args:
-            carrier: dictionary in which to get value
-            key: the key used to get the value
-        Returns:
-            A list with a single string with the value if it exists, else None.
-        """
-        val = carrier.get(key, None)
-        if val is None:
-            return None
-        if val.get("Value") is not None:
-            return [val.get("Value")]
-        return None
-
-    def keys(
-        self, carrier: typing.Mapping[str, textmap.CarrierValT]
-    ) -> typing.List[str]:
-        """Keys implementation that returns all keys from a dictionary."""
-        return list(carrier.keys())

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/attributes.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/attributes.py
@@ -1,0 +1,15 @@
+"""
+This module provides a set of attributes for AWS Lambda functions.
+"""
+
+AWS_EVENT_BRIDGE_TRIGGER_SOURCE = "aws.event.bridge.trigger.source"
+
+FAAS_TRIGGER_TYPE = "faas.trigger.type"
+
+HTTP_HEADER_PREFIX = "http.request.header."
+HTTP_RESPONSE_BODY = "http.response.body"
+
+MESSAGING_MESSAGE = "messaging.message"
+
+RPC_REQUEST_BODY = "rpc.request.body"
+RPC_RESPONSE_BODY = "rpc.response.body"

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/context.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/context.py
@@ -1,0 +1,76 @@
+from typing import Any, Callable, Optional
+
+from opentelemetry.context import Context
+from opentelemetry.propagate import get_global_textmap
+
+from opentelemetry.instrumentation.aws_lambda.coralogix.logger import cx_exception, cx_debug
+
+
+def determine_parent_context(
+    args: Any,
+    event_context_extractor: Optional[Callable[[Any], Context]],
+    upstream_context_extractor: Callable[[Any], Context],
+) -> Optional[Context]:
+    """Determine the parent context for the current Lambda invocation.
+
+    See more:
+    https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/instrumentation/aws-lambda.md#determining-the-parent-of-a-span
+
+    Args:
+        args: lambda provided arguments.
+        event_context_extractor: a method which takes the Lambda
+            Event as input and extracts an OTel Context from it. By default,
+            the context is extracted from the HTTP headers of an API Gateway
+            request.
+    Returns:
+        A Context with configuration found in the carrier.
+    """
+
+    if event_context_extractor is None:
+        return default_context_extractor(args, upstream_context_extractor)
+
+    return event_context_extractor(args)
+
+def default_context_extractor(
+        args: Any,
+        upstream_context_extractor: Callable[[Any], Context]
+) -> Optional[Context]:
+    """Default way of extracting the context from the Lambda Event for Coralogix Instrumentation.
+
+    This is a wrapper for _determine_parent_context.
+
+    Args:
+        args: lambda provided arguments.
+    Returns:
+        A Context with configuration found in the event.
+    """
+    if len(args) < 2:
+        cx_exception(Exception("Not enough arguments"), "Not enough arguments to get the parent context")
+
+    cx_debug("Getting parent context from arguments", args)
+
+    lambda_event = args[0]
+    context = args[1]
+
+    # Try to extract context from Lambda Event
+    parent_context : Optional[Context] = None
+    try:
+        parent_context = get_global_textmap().extract(context.client_context.custom)
+    except Exception as ex:  # pylint: disable=broad-except
+        cx_exception(ex, "Error extracting context from Lambda Event")
+        return None
+
+    cx_debug("Parent context extracted from Lambda Event", parent_context)
+
+    if parent_context:
+        return parent_context
+
+    # Use the upstream context extractor if no context was found in the Lambda Event
+    try:
+        parent_context = upstream_context_extractor(lambda_event)
+    except Exception as ex:  # pylint: disable=broad-except
+        cx_exception(ex, "Error extracting context from upstream")
+
+    cx_debug("Parent context extracted from upstream", parent_context)
+
+    return parent_context

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/instrumentor.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/instrumentor.py
@@ -1,0 +1,77 @@
+"""
+This module provides functionality for instrumenting AWS Lambda functions with OpenTelemetry.
+"""
+
+from typing import Any, List, Type, Optional
+
+from opentelemetry.trace import Tracer, Span
+from opentelemetry.context.context import Context
+from opentelemetry.semconv.resource import ResourceAttributes
+from opentelemetry.semconv.trace import SpanAttributes
+
+from opentelemetry.instrumentation.aws_lambda.coralogix.span import CoralogixSpan
+from opentelemetry.instrumentation.aws_lambda.coralogix.span.api_gateway import APIGatewaySpan
+from opentelemetry.instrumentation.aws_lambda.coralogix.span.cognito import CognitoSpan
+from opentelemetry.instrumentation.aws_lambda.coralogix.span.dynamo import DynamoSpan
+from opentelemetry.instrumentation.aws_lambda.coralogix.span.event_bridge import EventBridgeSpan
+from opentelemetry.instrumentation.aws_lambda.coralogix.span.kinesis import KinesisSpan
+from opentelemetry.instrumentation.aws_lambda.coralogix.span.s3 import S3Span
+from opentelemetry.instrumentation.aws_lambda.coralogix.span.sns import SNSSpan
+from opentelemetry.instrumentation.aws_lambda.coralogix.span.sqs import SQSSpan
+
+from opentelemetry.instrumentation.aws_lambda.coralogix.logger import cx_exception
+
+# There is no LambdaContext class in the AWS Lambda SDK, so we need to create our own.
+# There is a package called types-aws-lambda but last release was in 2021.
+class LambdaContext:
+    function_name: str
+    function_version: str
+    invoked_function_arn: str
+    memory_limit_in_mb: str
+    aws_request_id: str
+    log_group_name: str
+    log_stream_name: str
+
+
+def get_cx_instrumentor(
+        tracer: Tracer,
+        parent_context: Context,
+        lambda_event: Any,
+        orig_handler_name: str
+) -> Optional[CoralogixSpan]:
+    """
+    Get the span and context for the given lambda event.
+    """
+    instrumentor_classes: List[Type[CoralogixSpan]] = [
+        APIGatewaySpan,
+        S3Span,
+        SQSSpan,
+        SNSSpan,
+        KinesisSpan,
+        DynamoSpan,
+        CognitoSpan,
+        EventBridgeSpan,
+    ]
+
+    try:
+        for instrumentor_class in instrumentor_classes:
+            instrumentor = instrumentor_class(
+                tracer, parent_context, lambda_event, orig_handler_name
+            )
+            if instrumentor.is_applicable():
+                return instrumentor
+    except Exception as ex:  # pylint: disable=broad-except
+        cx_exception(ex, "Error instrumenting lambda function")
+
+    return None
+
+def set_cx_span_attributes(span: Span, lambda_context: LambdaContext) -> None:
+    """
+    Set the span attributes for the given lambda context.
+    """
+    span.set_attribute(
+        ResourceAttributes.FAAS_ID, lambda_context.invoked_function_arn
+    )
+    span.set_attribute(
+        SpanAttributes.FAAS_EXECUTION, lambda_context.aws_request_id,
+    )

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/logger.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/logger.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import traceback
+from typing import Any, Optional
+
+CX_DEBUG = os.getenv("CX_DEBUG", "").lower() == "true"
+
+
+def cx_debug(message: Any, *args: Any) -> None:
+    """
+    Logs a debug message if the CX_DEBUG environment variable is set to 'true'.
+    
+    print method is used to avoid any possible issues with instrumentation in logging library.
+
+    Args:
+        message: The message to be logged. Can be any type that can be converted to string.
+    """
+    if CX_DEBUG:
+        print(f"[DEBUG] {message}", *args)
+
+
+def cx_exception(exception: Exception, message: Optional[str] = None) -> None:
+    """
+    Logs detailed information about an exception including file, line number, and traceback.
+    Then re-raises the exception.
+    
+    print method is used to avoid any possible issues with instrumentation in logging library.
+
+    Args:
+        exception: The exception that was caught
+        message: Optional additional message to include in the log
+    """
+    if not CX_DEBUG:
+        return
+
+    _, _, exc_traceback = sys.exc_info()
+    if exc_traceback is not None:
+        frame = exc_traceback.tb_frame
+        filename = frame.f_code.co_filename
+        line_number = frame.f_lineno
+        function_name = frame.f_code.co_name
+
+        error_message = f"Exception in {filename}:{line_number} ({function_name})"
+        if message:
+            error_message += f" - {message}"
+        error_message += f"\nException: {str(exception)}"
+        error_message += f"\nTraceback:\n{''.join(traceback.format_tb(exc_traceback))}"
+
+        print(f"[ERROR] {error_message}")
+
+    raise exception

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/span/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/span/__init__.py
@@ -1,0 +1,89 @@
+"""
+This module provides functionality for creating OpenTelemetry spans for AWS Lambda functions.
+
+It contains the base CoralogixSpan class that defines the interface for creating spans for different
+AWS Lambda triggers, as well as concrete implementations for various AWS services like:
+
+"""
+from typing import Dict, Tuple, Any
+from dataclasses import dataclass, field
+from abc import ABC, abstractmethod
+from opentelemetry.context.context import Context
+from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.trace import Tracer, Span, SpanKind
+
+from opentelemetry.instrumentation.aws_lambda.utils import limit_string_size
+
+from opentelemetry.instrumentation.aws_lambda.coralogix import attributes as cx_attributes
+
+@dataclass
+class CoralogixSpan(ABC):
+    """
+    Base class for creating OpenTelemetry spans for AWS Lambda functions.
+
+    This class defines the interface for creating spans for different AWS Lambda triggers.
+    """
+    tracer: Tracer
+    parent_context: Context
+    lambda_event: Dict[str, Any]
+    orig_handler_name: str
+    generated_span: Span = field(init=False, repr=False)
+
+    @abstractmethod
+    def is_applicable(self) -> bool:
+        """
+        Check if the span is applicable for the given AWS Lambda event.
+        """
+
+    @abstractmethod
+    def before_run(self) -> Tuple[Span, Context]:
+        """
+        Create the span and context for the given AWS Lambda event.
+        """
+
+    def get_child_span_type(self) -> SpanKind:
+        """
+        Get the child span type for the given AWS Lambda event.
+        """
+        return None
+
+    def set_rpc_request_body(self, body: Any) -> None:
+        """
+        Set the request body for the given AWS Lambda event.
+        """
+        body = limit_string_size(str(body))
+        self.generated_span.set_attribute(cx_attributes.RPC_REQUEST_BODY, body)
+
+
+    def after_run(self, result: Dict[str, Any]) -> None:
+        """
+        After the lamda is executed, this method is called to perform any additional actions.
+        """
+        if not isinstance(result, dict):  # type: ignore[unnecessary-isinstance-call]
+            return
+
+        if result.get("statusCode"):
+            self.generated_span.set_attribute(
+                SpanAttributes.HTTP_STATUS_CODE,
+                result.get("statusCode") # type: ignore[unknown-get]
+            )
+
+        if result.get("body"):
+            self.generated_span.set_attribute(
+                cx_attributes.RPC_RESPONSE_BODY,
+                limit_string_size(str(result.get("body")))
+            )
+
+
+    @staticmethod
+    def get_queue_url(queue_url: str) -> str:
+        """
+        Extract the queue name from the queue URL.
+
+        Example queue_url: arn:aws:sqs:us-east-1:123456789012:my_queue_name
+        """
+        if ":" in queue_url:
+            splitted_queue_url = queue_url.split(":")
+            if len(splitted_queue_url) > 0:
+                queue_url = splitted_queue_url[-1]
+        return queue_url

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/span/api_gateway.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/span/api_gateway.py
@@ -1,0 +1,81 @@
+"""
+This module provides functionality for creating OpenTelemetry spans for API Gateway events.
+"""
+
+from typing import Dict, Tuple, Any
+
+from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.trace import set_span_in_context, Span, SpanKind
+from opentelemetry.context.context import Context
+from opentelemetry.instrumentation.aws_lambda.utils import limit_string_size
+from opentelemetry.instrumentation.aws_lambda.coralogix.span import CoralogixSpan
+from opentelemetry.instrumentation.aws_lambda.coralogix import attributes as cx_attributes
+
+class APIGatewaySpan(CoralogixSpan):
+    """
+    Span for API Gateway events.
+    """
+
+    def is_applicable(self) -> bool:
+        # If the request came from an API Gateway, extract http attributes from the event
+        # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/instrumentation/aws-lambda.md#api-gateway
+        # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-server-semantic-conventions
+        if not self.lambda_event.get("requestContext"):
+            return False
+
+        return True
+
+    def before_run(self) -> Tuple[Span, Context]:
+        # Get the span name
+        span_name = self.orig_handler_name
+        path = ""
+        if self.lambda_event.get(
+            "requestContext"
+        ) and self.lambda_event["requestContext"].get("http"):
+            span_name = str(self.lambda_event["requestContext"]["http"].get("path"))
+            path = span_name
+        elif self.lambda_event.get("resource"):
+            span_name = str(self.lambda_event.get("resource"))
+
+        # Create the span
+        self.generated_span = self.tracer.start_span(
+            span_name,
+            context=self.parent_context,
+            kind=SpanKind.CLIENT
+        )
+        if self.lambda_event.get("version") == "2.0":
+            self.generated_span.set_attribute(cx_attributes.FAAS_TRIGGER_TYPE, "Api Gateway Rest")
+        else:
+            self.generated_span.set_attribute(cx_attributes.FAAS_TRIGGER_TYPE, "Api Gateway HTTP")
+
+        self.generated_span.set_attribute(SpanAttributes.FAAS_TRIGGER, "http")
+
+        if self.lambda_event.get("headers"):
+            for key, value in self.lambda_event["headers"].items():
+                header_name = cx_attributes.HTTP_HEADER_PREFIX + key.lower().replace("-", "_")
+                self.generated_span.set_attribute(header_name, value)
+
+        if path:
+            self.generated_span.set_attribute(
+                SpanAttributes.HTTP_URL, path
+            )
+
+        if self.lambda_event.get("requestContext") and (
+            self.lambda_event["requestContext"].get("domainName") and path
+        ):
+            domain_name = self.lambda_event["requestContext"].get("domainName")
+            self.generated_span.set_attribute(
+                SpanAttributes.HTTP_URL, domain_name + path
+            )
+
+        return self.generated_span, set_span_in_context(self.generated_span)
+
+    def after_run(self, result: Dict[str, Any]) -> None:
+        if not isinstance(result, dict):  # type: ignore[unnecessary-isinstance-call]
+            # We need to double check because sometimes
+            # it can happen that the result is not a dict
+            return
+
+        if result.get("body"):
+            body = limit_string_size(str(result.get("body")))
+            self.generated_span.set_attribute(cx_attributes.HTTP_RESPONSE_BODY, str(body))

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/span/cognito.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/span/cognito.py
@@ -1,0 +1,42 @@
+"""
+This module provides functionality for creating OpenTelemetry spans for Cognito events.
+"""
+import json
+from typing import Tuple
+
+from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.trace import set_span_in_context, Span, SpanKind
+from opentelemetry.context.context import Context
+from opentelemetry.instrumentation.aws_lambda.coralogix.span import CoralogixSpan
+from opentelemetry.instrumentation.aws_lambda.coralogix import attributes as cx_attributes
+
+class CognitoSpan(CoralogixSpan):
+    """
+    Span for Cognito events.
+    """
+
+    def is_applicable(self) -> bool:
+        if not self.lambda_event.get("eventType"):
+            return False
+
+        if self.lambda_event.get("eventType") != "SyncTrigger":
+            return False
+
+        return True
+
+    def before_run(self) -> Tuple[Span, Context]:
+        # Get span name
+        span_name = "SyncTrigger"
+
+        self.generated_span = self.tracer.start_span(
+            span_name,
+            context=self.parent_context,
+            kind=SpanKind.PRODUCER
+        )
+        self.generated_span.set_attribute(SpanAttributes.FAAS_TRIGGER, "datasource")
+        self.generated_span.set_attribute(cx_attributes.FAAS_TRIGGER_TYPE, "Cognito")
+
+        if self.lambda_event.get("datasetRecords"):
+            self.set_rpc_request_body(json.dumps(self.lambda_event["datasetRecords"]))
+
+        return self.generated_span, set_span_in_context(self.generated_span)

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/span/dynamo.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/span/dynamo.py
@@ -1,0 +1,50 @@
+"""
+This module provides functionality for creating OpenTelemetry spans for DynamoDB events.
+"""
+
+import json
+from typing import Tuple, Dict, Any
+
+from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.trace import  set_span_in_context, Span, SpanKind
+from opentelemetry.context.context import Context
+
+from opentelemetry.instrumentation.aws_lambda.coralogix.span import CoralogixSpan
+from opentelemetry.instrumentation.aws_lambda.coralogix import attributes as cx_attributes
+
+class DynamoSpan(CoralogixSpan):
+    """
+    Span for DynamoDB events.
+    """
+
+    def is_applicable(self) -> bool:
+        records = self.lambda_event.get("Records")
+        if not records:
+            return False
+
+        if not records[0].get("eventSource"):
+            return False
+
+        return records[0].get("eventSource") == "aws:dynamodb"
+
+    def before_run(self) -> Tuple[Span, Context]:
+        # Get span name
+        records = self.lambda_event.get("Records")
+
+        first_record: Dict[str, Any] = records[0]  # type: ignore[index]
+        span_name = self.orig_handler_name
+        if first_record.get("eventName"):  # type: ignore[unknown-get]
+            span_name = str(first_record.get("eventName"))  # type: ignore[unknown-get]
+
+        self.generated_span = self.tracer.start_span(
+            span_name,
+            context=self.parent_context,
+            kind=SpanKind.PRODUCER
+        )
+        self.generated_span.set_attribute(SpanAttributes.FAAS_TRIGGER, "datasource")
+        self.generated_span.set_attribute(cx_attributes.FAAS_TRIGGER_TYPE, "Dynamo DB")
+
+        if first_record.get("dynamodb"):  # type: ignore[unknown-get]
+            self.set_rpc_request_body(json.dumps(first_record.get("dynamodb")))  # type: ignore[unknown-get]
+
+        return self.generated_span, set_span_in_context(self.generated_span)

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/span/event_bridge.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/span/event_bridge.py
@@ -1,0 +1,64 @@
+"""
+This module provides functionality for creating OpenTelemetry spans for EventBridge events.
+"""
+
+import json
+from typing import List, Tuple
+
+from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.trace import set_span_in_context, Span, SpanKind, span, Link
+from opentelemetry.context.context import Context
+from opentelemetry.propagate import get_global_textmap
+from opentelemetry.trace.propagation import get_current_span
+
+from opentelemetry.instrumentation.aws_lambda.coralogix.span import CoralogixSpan
+from opentelemetry.instrumentation.aws_lambda.coralogix import attributes as cx_attributes
+
+class EventBridgeSpan(CoralogixSpan):
+    """
+    Span for EventBridge events.
+    """
+
+    def is_applicable(self) -> bool:
+        if not self.lambda_event.get("source"):
+            return False
+
+        if not isinstance(self.lambda_event.get("source"), str):
+            return False
+
+        return True
+
+    def before_run(self) -> Tuple[Span, Context]:
+        # Get span name
+        span_name = 'EventBridge event'
+        if self.lambda_event.get("detail-type"):
+            span_name = str(self.lambda_event.get("detail-type"))
+
+        links: List[Link] = []
+        if self.lambda_event.get("detail") and self.lambda_event["detail"].get("_context"):
+            ctx = get_global_textmap().extract(carrier=self.lambda_event["detail"].get("_context"))
+            span_ctx = get_current_span(ctx).get_span_context()
+            if span_ctx.span_id != span.INVALID_SPAN_ID:
+                links.append(Link(span_ctx))
+
+        # Create the span
+        self.generated_span = self.tracer.start_span(
+            span_name,
+            context=self.parent_context,
+            kind=SpanKind.CONSUMER,
+            links=links
+        )
+        self.generated_span.set_attribute(
+            SpanAttributes.FAAS_TRIGGER, "pubsub"
+        )
+        self.generated_span.set_attribute(
+            cx_attributes.FAAS_TRIGGER_TYPE, "EventBridge"
+        )
+        self.generated_span.set_attribute(
+            cx_attributes.AWS_EVENT_BRIDGE_TRIGGER_SOURCE,
+            str(self.lambda_event.get("source"))
+        )
+
+        self.set_rpc_request_body(json.dumps(self.lambda_event))
+
+        return self.generated_span, set_span_in_context(self.generated_span)

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/span/kinesis.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/span/kinesis.py
@@ -1,0 +1,103 @@
+
+"""
+This module provides functionality for creating OpenTelemetry spans for Kinesis events.
+"""
+
+from typing import List, Tuple, Dict, Any
+import base64
+import json
+
+from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.trace import set_span_in_context, Span, SpanKind
+from opentelemetry.context.context import Context
+from opentelemetry.trace import Link, span
+from opentelemetry.propagate import get_global_textmap
+from opentelemetry.trace.propagation import get_current_span
+
+from opentelemetry.instrumentation.aws_lambda.coralogix.span import CoralogixSpan
+from opentelemetry.instrumentation.aws_lambda.coralogix import attributes as cx_attributes
+
+class KinesisSpan(CoralogixSpan):
+    """
+    Span for Kinesis events.
+    """
+
+    def is_applicable(self) -> bool:
+        records = self.lambda_event.get("Records")
+        if not records:
+            return False
+
+        if not records[0].get("eventSource"):
+            return False
+
+        return records[0].get("eventSource") == "aws:kinesis"
+
+    def get_child_span_type(self) -> SpanKind:
+        return SpanKind.INTERNAL
+
+    def before_run(self) -> Tuple[Span, Context]:
+        links: List[Link] = []
+        queue_url = ""
+
+        records = self.lambda_event.get("Records")
+
+        for record in records:  # type: ignore[index]
+            if record.get("kinesis") is None:
+                continue
+
+            if queue_url == "":
+                queue_url = record.get("eventSourceARN")
+
+            data = record["kinesis"].get("data")
+            if data is not None:
+                decoded_bytes = base64.b64decode(data)
+                decoded_string = decoded_bytes.decode('utf-8')
+                data = json.loads(decoded_string)
+                ctx = get_global_textmap().extract(carrier=data.get("_context"))
+                span_ctx = get_current_span(ctx).get_span_context()
+                if span_ctx.span_id != span.INVALID_SPAN_ID:
+                    links.append(Link(span_ctx))
+
+        # Get span name
+        span_name = self.orig_handler_name
+
+        # Create the span
+        self.generated_span = self.tracer.start_span(
+            span_name,
+            context=self.parent_context,
+            kind=SpanKind.CONSUMER,
+            links=links
+        )
+        self.generated_span.set_attribute(
+            SpanAttributes.FAAS_TRIGGER, "pubsub"
+        )
+        self.generated_span.set_attribute(
+            cx_attributes.FAAS_TRIGGER_TYPE, "Kinesis"
+        )
+        self.generated_span.set_attribute(
+            SpanAttributes.MESSAGING_SYSTEM, "aws.kinesis"
+        )
+        self.generated_span.set_attribute(
+            SpanAttributes.MESSAGING_URL, queue_url
+        )
+
+        dest = KinesisSpan.get_queue_url(queue_url)
+        if dest:
+            self.generated_span.set_attribute(SpanAttributes.MESSAGING_DESTINATION, dest)
+
+        first_record: Dict[str, Any] = records[0]  # type: ignore[index]
+        if first_record.get("kinesis") and first_record["kinesis"].get("data"):  # type: ignore[unknown-get]
+            decoded_bytes = base64.b64decode(first_record["kinesis"].get("data"))  # type: ignore[unknown-get]
+            decoded_string = decoded_bytes.decode('utf-8')
+            body = json.loads(decoded_string)
+
+            self.set_rpc_request_body(body)
+
+        return self.generated_span, set_span_in_context(self.generated_span)
+
+    def after_run(self, result: Dict[str, Any]) -> None:
+        if result.get("ResponseMetadata") and result.get("ResponseMetadata").get("HTTPStatusCode"):  # type: ignore[unknown-get]
+            self.generated_span.set_attribute(
+                SpanAttributes.HTTP_STATUS_CODE,
+                result.get("ResponseMetadata").get("HTTPStatusCode")  # type: ignore[unknown-get]
+            )

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/span/s3.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/span/s3.py
@@ -1,0 +1,51 @@
+"""
+This module provides functionality for creating OpenTelemetry spans for S3 events.
+"""
+
+import json
+from typing import Tuple, Dict, Any
+
+from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.trace import set_span_in_context, Span, SpanKind
+from opentelemetry.context.context import Context
+
+from opentelemetry.instrumentation.aws_lambda.coralogix.span import CoralogixSpan
+from opentelemetry.instrumentation.aws_lambda.coralogix import attributes as cx_attributes
+
+class S3Span(CoralogixSpan):
+    """
+    Span for S3 events.
+    """
+
+    def is_applicable(self) -> bool:
+        records = self.lambda_event.get("Records")
+        if not records:
+            return False
+
+        if not records[0].get("eventSource"):
+            return False
+
+        return records[0].get("eventSource") == "aws:s3"
+
+    def before_run(self) -> Tuple[Span, Context]:
+        # Get span name
+        records = self.lambda_event.get("Records")
+        first_record: Dict[str, Any] = records[0]  # type: ignore[index]
+        span_name = self.orig_handler_name
+        if first_record.get("eventName"):  # type: ignore[unknown-get]
+            span_name = str(first_record.get("eventName"))  # type: ignore[unknown-get]
+
+        # Create the span
+        self.generated_span = self.tracer.start_span(
+            span_name,
+            context=self.parent_context,
+            kind=SpanKind.PRODUCER
+        )
+        self.generated_span.set_attribute(SpanAttributes.FAAS_TRIGGER, "datasource")
+        self.generated_span.set_attribute(cx_attributes.FAAS_TRIGGER_TYPE, "S3")
+
+        if first_record.get("s3"):  # type: ignore[unknown-get]
+            event = first_record.get("s3")  # type: ignore[unknown-get]
+            self.set_rpc_request_body(json.dumps(event))
+
+        return self.generated_span, set_span_in_context(self.generated_span)

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/span/sns.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/span/sns.py
@@ -1,0 +1,103 @@
+"""
+This module provides functionality for creating OpenTelemetry spans for SNS events.
+"""
+
+from typing import List, Mapping, Optional, Tuple, Dict, Any
+
+from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.trace import set_span_in_context, Span, SpanKind, Link, span
+from opentelemetry.context.context import Context
+from opentelemetry.propagate import get_global_textmap
+from opentelemetry.trace.propagation import get_current_span
+from opentelemetry.propagators import textmap
+
+from opentelemetry.instrumentation.aws_lambda.coralogix.span import CoralogixSpan
+from opentelemetry.instrumentation.aws_lambda.coralogix import attributes as cx_attributes
+
+class SNSSpan(CoralogixSpan):
+    """
+    Span for SNS events.
+    """
+
+    def is_applicable(self) -> bool:
+        records = self.lambda_event.get("Records")
+        if not records:
+            return False
+
+        if not records[0].get("EventSource"):
+            return False
+
+        return records[0].get("EventSource") == "aws:sns"
+
+    def get_child_span_type(self) -> SpanKind:
+        return SpanKind.INTERNAL
+
+    def before_run(self) -> Tuple[Span, Context]:
+        links: List[Link] = []
+        queue_url = ""
+        records = self.lambda_event.get("Records")
+
+        for record in records:  # type: ignore[index]
+            if record.get("Sns") is None:
+                continue
+
+            if queue_url == "":
+                queue_url = record.get("Sns").get("TopicArn")
+
+            attributes = record.get("Sns").get("MessageAttributes")
+            if attributes is not None:
+                ctx = get_global_textmap().extract(carrier=attributes, getter=SNSGetter())  # type: ignore[arg-type]
+                span_ctx = get_current_span(ctx).get_span_context()
+                if span_ctx.span_id != span.INVALID_SPAN_ID:
+                    links.append(Link(span_ctx))
+
+        # Get span name
+        span_name = self.orig_handler_name
+        # Create the span
+        self.generated_span = self.tracer.start_span(
+            span_name,
+            context=self.parent_context,
+            kind=SpanKind.CONSUMER,
+            links=links
+        )
+        self.generated_span.set_attribute(SpanAttributes.FAAS_TRIGGER, "pubsub")
+        self.generated_span.set_attribute(cx_attributes.FAAS_TRIGGER_TYPE, "SNS")
+        self.generated_span.set_attribute(SpanAttributes.MESSAGING_SYSTEM, "aws.sns")
+        self.generated_span.set_attribute(SpanAttributes.MESSAGING_URL, queue_url)
+
+        dest = SNSSpan.get_queue_url(queue_url)
+        if dest:
+            self.generated_span.set_attribute(SpanAttributes.MESSAGING_DESTINATION, dest)
+
+        first_record: Dict[str, Any] = records[0]  # type: ignore[index]
+        if first_record.get("Sns") and first_record["Sns"].get("Message"):  # type: ignore[unknown-get]
+            self.set_rpc_request_body(first_record["Sns"].get("Message"))  # type: ignore[unknown-get]
+        return self.generated_span, set_span_in_context(self.generated_span)
+
+
+class SNSGetter():
+    """
+    Getter implementation to retrieve a value from a dictionary.
+    """
+
+    def get(
+        self, carrier: Mapping[str, textmap.CarrierValT], key: str
+    ) -> Optional[List[str]]:
+        """Getter implementation to retrieve a value from a dictionary.
+
+        Args:
+            carrier: dictionary in which to get value
+            key: the key used to get the value
+        Returns:
+            A list with a single string with the value if it exists, else None.
+        """
+        val = carrier.get(key, None)
+        if val is None:
+            return None
+        if val.get("Value") is not None:  # type: ignore[unknown-get]
+            return [val.get("Value")]  # type: ignore[unknown-get]
+        return None
+
+    def keys(self, carrier: Mapping[str, textmap.CarrierValT]) -> List[str]:
+        """Keys implementation that returns all keys from a dictionary."""
+        return list(carrier.keys())

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/span/sqs.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/span/sqs.py
@@ -1,0 +1,104 @@
+"""
+This module provides functionality for creating OpenTelemetry spans for SQS events.
+"""
+
+from typing import List, Mapping, Optional, Tuple
+
+from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.trace import set_span_in_context, Span, SpanKind, Link, span
+from opentelemetry.context.context import Context
+from opentelemetry.propagate import get_global_textmap
+from opentelemetry.trace.propagation import get_current_span
+from opentelemetry.propagators import textmap
+from opentelemetry.instrumentation.aws_lambda.utils import limit_string_size
+
+from opentelemetry.instrumentation.aws_lambda.coralogix.span import CoralogixSpan
+from opentelemetry.instrumentation.aws_lambda.coralogix import attributes as cx_attributes
+
+class SQSSpan(CoralogixSpan):
+    """
+    Span for SQS events.
+    """
+
+    def is_applicable(self) -> bool:
+        records = self.lambda_event.get("Records")
+        if not records:
+            return False
+
+        if not records[0].get("eventSource"):
+            return False
+        return "aws:sqs" in records[0].get("eventSource")
+
+    def before_run(self) -> Tuple[Span, Context]:
+        links: List[Link] = []
+        queue_url = ""
+
+        records = self.lambda_event.get("Records")
+        for record in records:  # type: ignore[index]
+            if queue_url == "":
+                queue_url = record.get("eventSourceARN")
+
+            attributes = record.get("messageAttributes")
+            if attributes is not None:
+                ctx = get_global_textmap().extract(carrier=attributes, getter=SQSGetter())  # type: ignore[arg-type]
+                span_ctx = get_current_span(ctx).get_span_context()
+                if span_ctx.span_id != span.INVALID_SPAN_ID:
+                    links.append(Link(span_ctx))
+
+
+        # Get span name
+        span_name = self.orig_handler_name
+
+        # Create the span
+        self.generated_span = self.tracer.start_span(
+            span_name,
+            context=self.parent_context,
+            kind=SpanKind.CONSUMER,
+            links=links
+        )
+        self.generated_span.set_attribute(SpanAttributes.FAAS_TRIGGER, "pubsub")
+        self.generated_span.set_attribute(cx_attributes.FAAS_TRIGGER_TYPE, "SQS")
+        self.generated_span.set_attribute(SpanAttributes.MESSAGING_SYSTEM, "aws.sqs")
+        self.generated_span.set_attribute(SpanAttributes.MESSAGING_URL, queue_url)
+
+        if records:
+            first_record = records[0]
+            body = limit_string_size(first_record.get("body"))
+            self.generated_span.set_attribute(cx_attributes.MESSAGING_MESSAGE, body)
+            self.set_rpc_request_body(body)
+
+        dest = SQSSpan.get_queue_url(queue_url)
+        if dest:
+            self.generated_span.set_attribute(SpanAttributes.MESSAGING_DESTINATION, dest)
+
+        return self.generated_span, set_span_in_context(self.generated_span)
+
+
+class SQSGetter():
+    """
+    Getter implementation to retrieve a value from a dictionary.
+    """
+
+    def get(
+        self, carrier: Mapping[str, textmap.CarrierValT], key: str
+    ) -> Optional[List[str]]:
+        """Getter implementation to retrieve a value from a dictionary.
+
+        Args:
+            carrier: dictionary in which to get value
+            key: the key used to get the value
+        Returns:
+            A list with a single string with the value if it exists, else None.
+        """
+        val = carrier.get(key, None)
+        if val is None:
+            return None
+        if val.get("stringValue") is not None:  # type: ignore[unknown-get]
+            return [val.get("stringValue")]  # type: ignore[unknown-get]
+        return None
+
+    def keys(
+        self, carrier: Mapping[str, textmap.CarrierValT]
+    ) -> List[str]:
+        """Keys implementation that returns all keys from a dictionary."""
+        return list(carrier.keys())

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/__init__.py
@@ -28,7 +28,7 @@ Usage
 .. code:: python
 
     from opentelemetry.instrumentation.botocore import BotocoreInstrumentor
-    import botocore
+    import botocore.session
 
 
     # Instrument Botocore
@@ -39,7 +39,7 @@ Usage
     session.set_credentials(
         access_key="access-key", secret_key="secret-key"
     )
-    ec2 = self.session.create_client("ec2", region_name="us-west-2")
+    ec2 = session.create_client("ec2", region_name="us-west-2")
     ec2.describe_instances()
 
 API
@@ -58,13 +58,15 @@ for example:
 .. code: python
 
     from opentelemetry.instrumentation.botocore import BotocoreInstrumentor
-    import botocore
+    import botocore.session
 
     def request_hook(span, service_name, operation_name, api_params):
         # request hook logic
+        pass
 
     def response_hook(span, service_name, operation_name, result):
         # response hook logic
+        pass
 
     # Instrument Botocore with hooks
     BotocoreInstrumentor().instrument(request_hook=request_hook, response_hook=response_hook)
@@ -74,21 +76,16 @@ for example:
     session.set_credentials(
         access_key="access-key", secret_key="secret-key"
     )
-    ec2 = self.session.create_client("ec2", region_name="us-west-2")
+    ec2 = session.create_client("ec2", region_name="us-west-2")
     ec2.describe_instances()
 """
 
 import logging
 from typing import Any, Callable, Collection, Dict, Optional, Tuple
-import json
-import io
-import os
-import base64
 
 from botocore.client import BaseClient
 from botocore.endpoint import Endpoint
 from botocore.exceptions import ClientError
-from botocore.response import StreamingBody
 from wrapt import wrap_function_wrapper
 
 from opentelemetry._events import get_event_logger
@@ -109,10 +106,15 @@ from opentelemetry.instrumentation.utils import (
     suppress_http_instrumentation,
     unwrap,
 )
+from opentelemetry.metrics import Instrument, Meter, get_meter
 from opentelemetry.propagators.aws.aws_xray_propagator import AwsXRayPropagator
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace import get_tracer
 from opentelemetry.trace.span import Span
+
+
+from opentelemetry.instrumentation.botocore import coralogix as coralogix_helpers
+from opentelemetry.instrumentation.botocore.coralogix.logger import cx_exception
 
 logger = logging.getLogger(__name__)
 
@@ -139,16 +141,13 @@ class BotocoreInstrumentor(BaseInstrumentor):
         self._tracers = {}
         # event_loggers are lazy initialized per-extension in _get_event_logger
         self._event_loggers = {}
+        # meters are lazy initialized per-extension in _get_meter
+        self._meters = {}
+        # metrics are lazy initialized per-extension in _get_metrics
+        self._metrics: Dict[str, Dict[str, Instrument]] = {}
 
         self.request_hook = kwargs.get("request_hook")
         self.response_hook = kwargs.get("response_hook")
-
-        try:
-            self.payload_size_limit = int(os.environ.get("OTEL_PAYLOAD_SIZE_LIMIT", 204800))
-        except ValueError:
-            logger.error(
-                "OTEL_PAYLOAD_SIZE_LIMIT is not a number"
-            )
 
         propagator = kwargs.get("propagator")
         if propagator is not None:
@@ -156,6 +155,7 @@ class BotocoreInstrumentor(BaseInstrumentor):
 
         self.tracer_provider = kwargs.get("tracer_provider")
         self.event_logger_provider = kwargs.get("event_logger_provider")
+        self.meter_provider = kwargs.get("meter_provider")
 
         wrap_function_wrapper(
             "botocore.client",
@@ -213,6 +213,38 @@ class BotocoreInstrumentor(BaseInstrumentor):
 
         return self._event_loggers[instrumentation_name]
 
+    def _get_meter(self, extension: _AwsSdkExtension):
+        """This is a multiplexer in order to have a meter per extension"""
+
+        instrumentation_name = self._get_instrumentation_name(extension)
+        meter = self._meters.get(instrumentation_name)
+        if meter:
+            return meter
+
+        schema_version = extension.meter_schema_version()
+        self._meters[instrumentation_name] = get_meter(
+            instrumentation_name,
+            "",
+            schema_url=f"https://opentelemetry.io/schemas/{schema_version}",
+            meter_provider=self.meter_provider,
+        )
+
+        return self._meters[instrumentation_name]
+
+    def _get_metrics(
+        self, extension: _AwsSdkExtension, meter: Meter
+    ) -> Dict[str, Instrument]:
+        """This is a multiplexer for lazy initialization of metrics required by extensions"""
+        instrumentation_name = self._get_instrumentation_name(extension)
+        metrics = self._metrics.get(instrumentation_name)
+        if metrics is not None:
+            return metrics
+
+        self._metrics.setdefault(instrumentation_name, {})
+        metrics = self._metrics[instrumentation_name]
+        _safe_invoke(extension.setup_metrics, meter, metrics)
+        return metrics
+
     def _uninstrument(self, **kwargs):
         unwrap(BaseClient, "_make_api_call")
         unwrap(Endpoint, "prepare_request")
@@ -251,50 +283,22 @@ class BotocoreInstrumentor(BaseInstrumentor):
             "aws.region": call_context.region,
         }
 
-        try:
-            if call_context.operation == "ListObjects":
-                bucket = call_context.params.get("Bucket")
-                if bucket is not None:
-                    attributes["rpc.request.payload"] = bucket
-            elif call_context.operation == "PutObject":
-                body = call_context.params.get("Body")
-                if body is not None:
-                    attributes["rpc.request.payload"] = body.decode('ascii')
-            elif call_context.operation == "PutItem":
-                body = call_context.params.get("Item")
-                if body is not None:
-                    attributes["rpc.request.payload"] = json.dumps(body, default=str)
-            elif call_context.operation == "GetItem":
-                body = call_context.params.get("Key")
-                if body is not None:
-                    attributes["rpc.request.payload"] = json.dumps(body, default=str)
-            elif call_context.operation == "Publish":
-                body = call_context.params.get("Message")
-                if body is not None:
-                    attributes["rpc.request.payload"] = json.dumps(body, default=str)
-            elif call_context.service == "kinesis" and (call_context.operation == "PutRecord" or call_context.operation == "PutRecords"):
-                call_context.span_kind = SpanKind.PRODUCER
-                streamName = call_context.params.get("StreamName")
-                if streamName:
-                    attributes[SpanAttributes.MESSAGING_SYSTEM] = "aws.kinesis"
-                    attributes[SpanAttributes.MESSAGING_DESTINATION] = streamName
-                attributes["rpc.request.payload"] = limit_string_size(json.dumps(call_context.params, default=str))
-            elif call_context.service == "sqs" and (call_context.operation == "SendMessageBatch" or call_context.operation == "SendMessage"):
-                call_context.span_kind = SpanKind.PRODUCER
-                attributes["rpc.request.payload"] = limit_string_size(json.dumps(call_context.params, default=str))
-            else:
-                attributes["rpc.request.payload"] = json.dumps(call_context.params, default=str)
-        except Exception as ex:
-            pass
+        coralogix_helpers.add_extra_attributes(call_context, attributes)
 
         _safe_invoke(extension.extract_attributes, attributes)
         end_span_on_exit = extension.should_end_span_on_exit()
 
         tracer = self._get_tracer(extension)
         event_logger = self._get_event_logger(extension)
+        meter = self._get_meter(extension)
+        metrics = self._get_metrics(extension, meter)
         instrumentor_ctx = _BotocoreInstrumentorContext(
-            event_logger=event_logger
+            event_logger=event_logger,
+            metrics=metrics,
         )
+
+
+
         with tracer.start_as_current_span(
             call_context.span_name,
             kind=call_context.span_kind,
@@ -307,46 +311,10 @@ class BotocoreInstrumentor(BaseInstrumentor):
             self._call_request_hook(span, call_context)
 
             try:
-                if call_context.service == "lambda" and call_context.operation == "Invoke":
-                    if args[1].get("ClientContext") is not None:
-                        ctx = base64.b64decode(args[1].get("ClientContext")).decode('ascii')
-                        inject(ctx['custom'])
-                        jctx = json.dumps(ctx)
-                        args[1]['ClientContext'] = base64.b64encode(jctx.encode('ascii')).decode('ascii')
-                    else:
-                        #ctx = {'custom': {'traceContext':{}}}
-                        #inject(ctx['custom']['traceContext'])
-                        ctx = {'custom': {}}
-                        inject(ctx['custom'])
-                        jctx = json.dumps(ctx)
-                        args[1]['ClientContext'] = base64.b64encode(jctx.encode('ascii')).decode('ascii')
+                coralogix_helpers.add_extra_context(call_context, args)
+            except Exception as e:  # pylint: disable=broad-except
+                cx_exception(e, "Error adding extra context to span")
 
-            except Exception as ex:
-                pass
-
-            try:
-                if call_context.service == "kinesis" and call_context.operation == "PutRecord":
-                    if args[1].get("Data") is not None:
-                        detailJson = json.loads(args[1].get("Data"))
-                        detailJson['_context'] = {}
-                        inject(carrier = detailJson['_context'])
-                        args[1]["Data"] = json.dumps(detailJson)
-
-                if call_context.service == "kinesis" and call_context.operation == "PutRecords":
-                    if args[1].get("Records") is not None:
-                        for entry in args[1].get("Records"):
-                            if entry.get("Data") is not None:
-                                detailJson = json.loads(entry.get("Data"))
-                                detailJson['_context'] = {}
-                                inject(carrier = detailJson['_context'])
-                                entry['Data'] = json.dumps(detailJson)
-                            else:
-                                detailJson = {'_context': {}}
-                                inject(carrier = detailJson['_context'])
-                                entry['Data'] = json.dumps(detailJson)
-
-            except Exception as e:
-                pass
 
             try:
                 with suppress_http_instrumentation():
@@ -355,12 +323,12 @@ class BotocoreInstrumentor(BaseInstrumentor):
                         result = original_func(*args, **kwargs)
                     except ClientError as error:
                         result = getattr(error, "response", None)
-                        _apply_response_attributes(span, result, self.payload_size_limit)
+                        _apply_response_attributes(span, result)
                         _safe_invoke(
                             extension.on_error, span, error, instrumentor_ctx
                         )
                         raise
-                    _apply_response_attributes(span, result, self.payload_size_limit)
+                    _apply_response_attributes(span, result)
                     _safe_invoke(
                         extension.on_success, span, result, instrumentor_ctx
                     )
@@ -390,7 +358,7 @@ class BotocoreInstrumentor(BaseInstrumentor):
         )
 
 
-def _apply_response_attributes(span: Span, result, payload_size_limit: int):
+def _apply_response_attributes(span: Span, result):
     if result is None or not span.is_recording():
         return
 
@@ -420,43 +388,7 @@ def _apply_response_attributes(span: Span, result, payload_size_limit: int):
     if status_code is not None:
         span.set_attribute(SpanAttributes.HTTP_STATUS_CODE, status_code)
 
-    try:
-        headers = metadata.get("HTTPHeaders")
-        if headers is not None:
-            server = headers.get("server")
-            if server == "AmazonS3":
-                buckets = result.get("Buckets")
-                content = result.get("Contents")
-                body = result.get("Body")
-                if buckets is not None:
-                    span.set_attribute(
-                        "rpc.response.payload", json.dumps([b.get("Name") for b in buckets]))
-                elif content is not None:
-                    span.set_attribute(
-                        "rpc.response.payload", json.dumps([b.get("Key") for b in content]))
-                elif body is not None:
-                    pass
-                else:
-                    span.set_attribute(
-                        "rpc.response.payload", json.dumps(result, default=str))
-            # Lambda Invoke
-            elif result.get("Payload") is not None and result.get("Payload")._content_length is not None and int(result.get("Payload")._content_length) < payload_size_limit:
-                length = result.get("Payload")._content_length
-                strbody = result.get("Payload").read()
-                result.get("Payload").close()
-                span.set_attribute(
-                    "rpc.response.payload", strbody)
-                result['Payload'] = StreamingBody(io.BytesIO(strbody), content_length=length)
-            # DynamoDB get item
-            elif server == "Server":
-                span.set_attribute(
-                    "rpc.response.payload", json.dumps(result, default=str))
-            else:
-                span.set_attribute(
-                    "rpc.response.payload", json.dumps(result, default=str))
-    except Exception as ex:
-        pass
-
+    coralogix_helpers.add_extra_attributes_after_call(metadata, result, span)
 
 
 def _determine_call_context(

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/coralogix/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/coralogix/__init__.py
@@ -1,0 +1,258 @@
+
+from typing import Any, Dict, List, Callable, MutableMapping
+import json
+import base64
+import io
+
+from opentelemetry.propagators import textmap
+from botocore.response import StreamingBody
+
+
+from opentelemetry.propagate import inject
+from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.instrumentation.botocore.extensions.types import (
+    _AwsSdkCallContext,
+)
+from opentelemetry.trace import SpanKind, Span
+from opentelemetry.instrumentation.botocore.utils import limit_string_size, get_payload_size_limit
+
+
+# pylint: disable=unused-argument
+def _patched_endpoint_prepare_request(wrapped, instance, args, kwargs):
+    request = args[0]
+    headers = request.headers
+    inject(headers)
+
+    return wrapped(*args, **kwargs)
+
+
+RPC_REQUEST_PAYLOAD = "rpc.request.payload"
+RPC_RESPONSE_PAYLOAD = "rpc.response.payload"
+
+def add_extra_attributes(call_context: _AwsSdkCallContext, attributes: Dict[str, Any]):
+    """
+    Add extra attributes to the span based on the call context.
+    """
+    if call_context.operation == "ListObjects":
+        bucket = call_context.params.get("Bucket")
+        if bucket:
+            attributes[RPC_REQUEST_PAYLOAD] = limit_string_size(bucket)
+
+    elif call_context.operation == "PutObject":
+        body = call_context.params.get("Body")
+        if body:
+            if isinstance(body, bytes):
+                payload = body.decode('ascii')
+            else:
+                payload = str(body)
+            attributes[RPC_REQUEST_PAYLOAD] = limit_string_size(payload)
+
+    elif call_context.operation == "PutItem":
+        body = call_context.params.get("Item")
+        if body:
+            attributes[RPC_REQUEST_PAYLOAD] = limit_string_size(json.dumps(body, default=str))
+
+    elif call_context.operation == "GetItem":
+        body = call_context.params.get("Key")
+        if body:
+            attributes[RPC_REQUEST_PAYLOAD] = limit_string_size(json.dumps(body, default=str))
+
+    elif call_context.operation == "Publish":
+        body = call_context.params.get("Message")
+        if body:
+            attributes[RPC_REQUEST_PAYLOAD] = limit_string_size(json.dumps(body, default=str))
+
+    elif call_context.service == "events" and call_context.operation == "PutEvents":
+        call_context.span_kind = SpanKind.PRODUCER
+        attributes[RPC_REQUEST_PAYLOAD] = limit_string_size(
+            json.dumps(call_context.params, default=str)
+        )
+
+    elif call_context.service == "kinesis" and (
+        call_context.operation in ["PutRecord", "PutRecords"]
+    ):
+        call_context.span_kind = SpanKind.PRODUCER
+        stream_name = call_context.params.get("StreamName")
+        if stream_name:
+            attributes[SpanAttributes.MESSAGING_SYSTEM] = "aws.kinesis"
+            attributes[SpanAttributes.MESSAGING_DESTINATION] = stream_name
+        attributes[RPC_REQUEST_PAYLOAD] = limit_string_size(
+            json.dumps(call_context.params, default=str)
+        )
+
+    elif call_context.service == "sqs" and (
+        call_context.operation in ["SendMessageBatch", "SendMessage"]
+    ):
+        call_context.span_kind = SpanKind.PRODUCER
+        attributes[RPC_REQUEST_PAYLOAD] = limit_string_size(
+            json.dumps(call_context.params, default=str)
+        )
+
+    else:
+        attributes[RPC_REQUEST_PAYLOAD] = limit_string_size(
+            json.dumps(call_context.params, default=str)
+        )
+
+
+def lambda_extra_context(call_context: _AwsSdkCallContext, args: List[Any]):
+    """
+    Add extra context for lambda function.
+    """
+    if call_context.operation == "Invoke":
+        if args[1].get("ClientContext"):
+            ctx = base64.b64decode(args[1].get("ClientContext")).decode('ascii')
+            inject(ctx['custom'])
+            jctx = json.dumps(ctx)
+            args[1]['ClientContext'] = base64.b64encode(jctx.encode('ascii')).decode('ascii')
+        else:
+            ctx = {'custom': {}}
+            inject(ctx['custom'])
+            jctx = json.dumps(ctx)
+            args[1]['ClientContext'] = base64.b64encode(jctx.encode('ascii')).decode('ascii')
+
+def sqs_extra_context(call_context: _AwsSdkCallContext, args: List[Any]):
+    """
+    Add extra context for sqs function.
+    """
+    if call_context.operation == "SendMessage":
+        if args[1].get("MessageAttributes"):
+            inject(carrier = args[1].get("MessageAttributes"), setter=SQSSetter())
+        else:
+            args[1]['MessageAttributes'] = {}
+            inject(carrier = args[1].get("MessageAttributes"), setter=SQSSetter())
+
+    elif call_context.operation == "SendMessageBatch":
+        if args[1].get("Entries"):
+            for entry in args[1].get("Entries"):
+                if entry.get("MessageAttributes"):
+                    inject(carrier = entry.get("MessageAttributes"), setter=SQSSetter())
+                else:
+                    entry['MessageAttributes'] = {}
+                    inject(carrier = entry.get("MessageAttributes"), setter=SQSSetter())
+
+
+def event_extra_context(call_context: _AwsSdkCallContext, args: List[Any]):
+    """
+    Add extra context for event function.
+    """
+    if call_context.operation != "PutEvents":
+        return
+
+    if not args[1].get("Entries"):
+        return
+
+    for entry in args[1].get("Entries"):
+        if entry.get("Detail"):
+            detail_json = json.loads(entry.get("Detail"))
+            detail_json['_context'] = {}
+            inject(carrier = detail_json['_context'])
+            entry['Detail'] = json.dumps(detail_json)
+        else:
+            detail_json = {'_context': {}}
+            inject(carrier = detail_json['_context'])
+            entry['Detail'] = json.dumps(detail_json)
+
+
+def kinesis_extra_context(call_context: _AwsSdkCallContext, args: List[Any]):
+    """
+    Add extra context for kinesis function.
+    """
+    if call_context.operation == "PutRecord":
+        if args[1].get("Data") is not None:
+            detail_json = json.loads(args[1].get("Data"))
+            detail_json['_context'] = {}
+            inject(carrier = detail_json['_context'])
+            args[1]["Data"] = json.dumps(detail_json)
+
+    elif call_context.operation == "PutRecords":
+        if args[1].get("Records") is not None:
+            for entry in args[1].get("Records"):
+                if entry.get("Data") is not None:
+                    detail_json = json.loads(entry.get("Data"))
+                    detail_json['_context'] = {}
+                    inject(carrier = detail_json['_context'])
+                    entry['Data'] = json.dumps(detail_json)
+                else:
+                    detail_json = {'_context': {}}
+                    inject(carrier = detail_json['_context'])
+                    entry['Data'] = json.dumps(detail_json)
+
+def add_extra_context(call_context: _AwsSdkCallContext, args: List[Any]):
+    """
+    Add extra context to the span based on the call context.
+    """
+    if len(args) == 0:
+        return
+
+    services: Dict[str, Callable] = {
+        "lambda": lambda_extra_context,
+        "sqs": sqs_extra_context,
+        "events": event_extra_context,
+        "kinesis": kinesis_extra_context,
+    }
+
+    for service, extra_context_f in services.items():
+        if call_context.service == service:
+            extra_context_f(call_context, args)
+            return
+
+class SQSSetter():
+    """
+    Setter implementation to set a value into a dictionary.
+    """
+
+    def set(
+        self,
+        carrier: MutableMapping[str, textmap.CarrierValT],
+        key: str,
+        value: textmap.CarrierValT,
+    ) -> None:
+        """Setter implementation to set a value into a dictionary.
+
+        Args:
+            carrier: dictionary in which to set value
+            key: the key used to set the value
+            value: the value to set
+        """
+        val = {"DataType": "String", "StringValue": value}
+        carrier[key] = val
+
+def add_extra_attributes_after_call(metadata: Dict[str, Any], result: Dict[str, Any], span: Span):
+    """
+    Add extra attributes to the span after the call.
+    """
+    headers = metadata.get("HTTPHeaders")
+
+    if not headers:
+        return
+
+    server = headers.get("server")
+
+    if server == "AmazonS3":
+        buckets = result.get("Buckets")
+        content = result.get("Contents")
+        body = result.get("Body")
+        if buckets:
+            payload = limit_string_size(json.dumps([b.get("Name") for b in buckets]))
+            span.set_attribute(RPC_RESPONSE_PAYLOAD, payload)
+        elif content:
+            payload = limit_string_size(json.dumps([b.get("Key") for b in content]))
+            span.set_attribute(RPC_RESPONSE_PAYLOAD, payload)
+        elif body is not None:
+            pass # TODO: handle body
+        else:
+            payload = limit_string_size(json.dumps(result, default=str))
+            span.set_attribute(RPC_RESPONSE_PAYLOAD, payload)
+    # Lambda Invoke
+    elif result.get("Payload"):
+        invoke_payload = result.get("Payload")
+        length = invoke_payload._content_length # pylint: disable=protected-access
+        if length and int(length) < get_payload_size_limit():
+            strbody = invoke_payload.read()
+            invoke_payload.close()
+            payload = limit_string_size(strbody)
+            span.set_attribute(RPC_RESPONSE_PAYLOAD, payload)
+            result['Payload'] = StreamingBody(io.BytesIO(strbody), content_length=length)
+    else:
+        payload = limit_string_size(json.dumps(result, default=str))
+        span.set_attribute(RPC_RESPONSE_PAYLOAD, payload)

--- a/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/coralogix/logger.py
+++ b/instrumentation/opentelemetry-instrumentation-botocore/src/opentelemetry/instrumentation/botocore/coralogix/logger.py
@@ -1,0 +1,55 @@
+"""
+This module is used to log messages and exceptions to the console.
+It is used to debug the application and to log errors.
+"""
+import os
+import sys
+import traceback
+from typing import Any, Optional
+
+CX_DEBUG = os.getenv("CX_DEBUG", "").lower() == "true"
+
+
+def cx_debug(message: Any, *args: Any) -> None:
+    """
+    Logs a debug message if the CX_DEBUG environment variable is set to 'true'.
+    
+    print method is used to avoid any possible issues with instrumentation in logging library.
+
+    Args:
+        message: The message to be logged. Can be any type that can be converted to string.
+    """
+    if CX_DEBUG:
+        print(f"[DEBUG] {message}", *args)
+
+
+def cx_exception(exception: Exception, message: Optional[str] = None) -> None:
+    """
+    Logs detailed information about an exception including file, line number, and traceback.
+    Then re-raises the exception.
+    
+    print method is used to avoid any possible issues with instrumentation in logging library.
+
+    Args:
+        exception: The exception that was caught
+        message: Optional additional message to include in the log
+    """
+    if not CX_DEBUG:
+        return
+
+    _, _, exc_traceback = sys.exc_info()
+    if exc_traceback is not None:
+        frame = exc_traceback.tb_frame
+        filename = frame.f_code.co_filename
+        line_number = frame.f_lineno
+        function_name = frame.f_code.co_name
+
+        error_message = f"Exception in {filename}:{line_number} ({function_name})"
+        if message:
+            error_message += f" - {message}"
+        error_message += f"\nException: {str(exception)}"
+        error_message += f"\nTraceback:\n{''.join(traceback.format_tb(exc_traceback))}"
+
+        print(f"[ERROR] {error_message}")
+
+    raise exception


### PR DESCRIPTION
Fix missing context propagation for SQS messages.

Other changes introduced:
- Create separated packages for Coralogix related stuff
  + Introduced modular span creation for AWS Lambda triggers via Coralogix
  + Extracted non-standard attributes to a common file to make it easier to detect customizations in spans
  + Introduced some functions to enrich botocore spans
  + Added some helper methods to log messages and exceptions only when CX_DEBUG equals to "true"
- Removed duplicity of some operations
- Improved reliability: more checks, added some type assertion
- Fixed issues with linters
- Fixed issues in botocore allowing more spans to be created
- **Used the upstream methods with some small changes, reducing merge conflicts in the future**

Some work left for follow up PRs:
- Fix the tests
- Introduce new tests for the new modules
- Improve botocore instrumentation to be more similar to the was-lambda package
- Continue fixing linter errors

Before the regression:
![image](https://github.com/user-attachments/assets/96f7d6b5-d682-43a7-bc68-5ece48860d9f)

When the regression was introduced:
![image](https://github.com/user-attachments/assets/bd5e6e2d-3ed6-405b-b995-45e00249301d)

After this PR:
<img width="841" alt="Screenshot 2025-04-15 at 19 26 17" src="https://github.com/user-attachments/assets/bc6f7bcd-257f-43de-bc0c-3c0f0b4919bb" />
