### PR TITLE
[ES-740] feat: Add Step Functions support to Coralogix AWS Lambda instrumentation

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/attributes.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/attributes.py
@@ -13,3 +13,16 @@ MESSAGING_MESSAGE = "messaging.message"
 
 RPC_REQUEST_BODY = "rpc.request.body"
 RPC_RESPONSE_BODY = "rpc.response.body"
+
+# Step Functions specific attributes
+AWS_STEP_FUNCTIONS_EXECUTION_ARN = "aws.stepfunctions.execution.arn"
+AWS_STEP_FUNCTIONS_EXECUTION_NAME = "aws.stepfunctions.execution.name"
+AWS_STEP_FUNCTIONS_EXECUTION_TYPE = "aws.stepfunctions.execution.type"
+AWS_STEP_FUNCTIONS_ROLE_ARN = "aws.stepfunctions.role.arn"
+AWS_STEP_FUNCTIONS_EXECUTION_START_TIME = "aws.stepfunctions.execution.start_time"
+AWS_STEP_FUNCTIONS_EXECUTION_REDRIVE_COUNT = "aws.stepfunctions.execution.redrive_count"
+AWS_STEP_FUNCTIONS_STATE_NAME = "aws.stepfunctions.state.name"
+AWS_STEP_FUNCTIONS_STATE_ENTERED_TIME = "aws.stepfunctions.state.entered_time"
+AWS_STEP_FUNCTIONS_STATE_RETRY_COUNT = "aws.stepfunctions.state.retry_count"
+AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN = "aws.stepfunctions.state_machine.arn"
+AWS_STEP_FUNCTIONS_STATE_MACHINE_NAME = "aws.stepfunctions.state_machine.name"

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/instrumentor.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/instrumentor.py
@@ -18,6 +18,7 @@ from opentelemetry.instrumentation.aws_lambda.coralogix.span.kinesis import Kine
 from opentelemetry.instrumentation.aws_lambda.coralogix.span.s3 import S3Span
 from opentelemetry.instrumentation.aws_lambda.coralogix.span.sns import SNSSpan
 from opentelemetry.instrumentation.aws_lambda.coralogix.span.sqs import SQSSpan
+from opentelemetry.instrumentation.aws_lambda.coralogix.span.step_functions import StepFunctionsSpan
 
 from opentelemetry.instrumentation.aws_lambda.coralogix.logger import cx_exception
 
@@ -51,6 +52,7 @@ def get_cx_instrumentor(
         DynamoSpan,
         CognitoSpan,
         EventBridgeSpan,
+        StepFunctionsSpan,
     ]
 
     try:

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/span/step_functions.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/src/opentelemetry/instrumentation/aws_lambda/coralogix/span/step_functions.py
@@ -1,0 +1,124 @@
+"""
+This module provides functionality for creating OpenTelemetry spans for AWS Step Functions events.
+"""
+
+from typing import Optional, Tuple
+import re
+
+from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.semconv.resource import ResourceAttributes
+from opentelemetry.trace import set_span_in_context, Span, SpanKind
+from opentelemetry.context.context import Context
+from opentelemetry.instrumentation.aws_lambda.utils import limit_string_size
+
+from opentelemetry.instrumentation.aws_lambda.coralogix.span import CoralogixSpan
+from opentelemetry.instrumentation.aws_lambda.coralogix import attributes as cx_attributes
+
+
+class StepFunctionsSpan(CoralogixSpan):
+    """
+    Span for AWS Step Functions events.
+    """
+
+    def is_applicable(self) -> bool:
+        """
+        Check if the event is a Step Functions event by validating the presence of
+        required context objects.
+        """
+        # Check for executionContext
+        execution_context = self.lambda_event.get("executionContext")
+        if not execution_context or not isinstance(execution_context, dict):
+            return False
+        
+        # Validate required execution context fields
+        required_execution_fields = ["Id", "Name", "RoleArn", "StartTime"]
+        if not all(field in execution_context for field in required_execution_fields):
+            return False
+        
+        # Check for stateContext
+        state_context = self.lambda_event.get("stateContext")
+        if not state_context or not isinstance(state_context, dict):
+            return False
+        
+        # Validate required state context fields
+        required_state_fields = ["Name", "EnteredTime", "RetryCount"]
+        if not all(field in state_context for field in required_state_fields):
+            return False
+        
+        # Check for stateMachineContext
+        state_machine_context = self.lambda_event.get("stateMachineContext")
+        if not state_machine_context or not isinstance(state_machine_context, dict):
+            return False
+        
+        # Validate required state machine context fields
+        required_state_machine_fields = ["Id", "Name"]
+        if not all(field in state_machine_context for field in required_state_machine_fields):
+            return False
+        
+        return True
+
+    def before_run(self) -> Tuple[Span, Context]:
+        """
+        Create the span and context for the Step Functions event.
+        """
+        execution_context = self.lambda_event.get("executionContext", {})
+        state_context = self.lambda_event.get("stateContext", {})
+        state_machine_context = self.lambda_event.get("stateMachineContext", {})
+        
+        # Extract information from execution ARN
+        execution_arn = execution_context.get("Id", "")
+        arn_parts = execution_arn.split(":")
+        
+        # Parse ARN: arn:aws:states:region:account:express:StateMachineName:executionName:taskToken
+        region = arn_parts[3] if len(arn_parts) > 3 else "unknown"
+        account_id = arn_parts[4] if len(arn_parts) > 4 else "unknown"
+        execution_type = arn_parts[5] if len(arn_parts) > 5 else "unknown"  # 'express' or 'standard'
+        state_machine_name = arn_parts[6] if len(arn_parts) > 6 else "unknown"
+        
+        # Get span name (use state machine name)
+        span_name = state_machine_name
+        
+        # Create the span
+        self.generated_span = self.tracer.start_span(
+            span_name,
+            context=self.parent_context,
+            kind=SpanKind.SERVER
+        )
+        
+        # Set core FaaS attributes
+        self.generated_span.set_attribute(SpanAttributes.FAAS_TRIGGER, "stepfunctions")
+        self.generated_span.set_attribute(cx_attributes.FAAS_TRIGGER_TYPE, "Step Functions")
+        
+        # Set AWS Step Functions execution attributes
+        self.generated_span.set_attribute(cx_attributes.AWS_STEP_FUNCTIONS_EXECUTION_ARN, execution_arn)
+        self.generated_span.set_attribute(cx_attributes.AWS_STEP_FUNCTIONS_EXECUTION_NAME, execution_context.get("Name", ""))
+        self.generated_span.set_attribute(cx_attributes.AWS_STEP_FUNCTIONS_EXECUTION_TYPE, execution_type)
+        self.generated_span.set_attribute(cx_attributes.AWS_STEP_FUNCTIONS_ROLE_ARN, execution_context.get("RoleArn", ""))
+        self.generated_span.set_attribute(cx_attributes.AWS_STEP_FUNCTIONS_EXECUTION_START_TIME, execution_context.get("StartTime", ""))
+        self.generated_span.set_attribute(cx_attributes.AWS_STEP_FUNCTIONS_EXECUTION_REDRIVE_COUNT, execution_context.get("RedriveCount", 0))
+        
+        # Set cloud context attributes
+        self.generated_span.set_attribute(ResourceAttributes.CLOUD_REGION, region)
+        self.generated_span.set_attribute(ResourceAttributes.CLOUD_ACCOUNT_ID, account_id)
+        
+        # Set state context attributes
+        self.generated_span.set_attribute(cx_attributes.AWS_STEP_FUNCTIONS_STATE_NAME, state_context.get("Name", ""))
+        self.generated_span.set_attribute(cx_attributes.AWS_STEP_FUNCTIONS_STATE_ENTERED_TIME, state_context.get("EnteredTime", ""))
+        self.generated_span.set_attribute(cx_attributes.AWS_STEP_FUNCTIONS_STATE_RETRY_COUNT, state_context.get("RetryCount", 0))
+        
+        # Set state machine context attributes
+        self.generated_span.set_attribute(cx_attributes.AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN, state_machine_context.get("Id", ""))
+        self.generated_span.set_attribute(cx_attributes.AWS_STEP_FUNCTIONS_STATE_MACHINE_NAME, state_machine_name)
+        
+        # Set input data if available
+        input_data = self.lambda_event.get("input")
+        if input_data is not None:
+            self.set_rpc_request_body(input_data)
+        
+        return self.generated_span, set_span_in_context(self.generated_span)
+
+    def get_child_span_type(self) -> SpanKind:
+        """
+        Get the child span type for Step Functions events.
+        """
+        return SpanKind.SERVER

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/mocks/step_functions_event.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/mocks/step_functions_event.py
@@ -1,0 +1,22 @@
+"""
+Step Functions event for AWS Lambda integration testing
+"""
+
+MOCK_LAMBDA_STEP_FUNCTIONS_EVENT = {
+    "executionContext": {
+        "Id": "arn:aws:states:us-east-1:123456789012:execution:TestStateMachine:test-execution-123",
+        "Name": "test-execution-123",
+        "RoleArn": "arn:aws:iam::123456789012:role/StepFunctionsExecutionRole",
+        "StartTime": "2025-10-15T08:30:00.000Z",
+        "RedriveCount": 0
+    },
+    "stateContext": {
+        "Name": "InvokeLambda",
+        "EnteredTime": "2025-10-15T08:30:00.000Z",
+        "RetryCount": 0
+    },
+    "stateMachineContext": {
+        "Id": "arn:aws:states:us-east-1:123456789012:stateMachine:TestStateMachine",
+        "Name": "TestStateMachine"
+    }
+}

--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/tests/test_aws_lambda_instrumentation_manual.py
@@ -54,6 +54,7 @@ from .mocks.dynamo_db_event import MOCK_LAMBDA_DYNAMO_DB_EVENT
 from .mocks.s3_event import MOCK_LAMBDA_S3_EVENT
 from .mocks.sns_event import MOCK_LAMBDA_SNS_EVENT
 from .mocks.sqs_event import MOCK_LAMBDA_SQS_EVENT
+from .mocks.step_functions_event import MOCK_LAMBDA_STEP_FUNCTIONS_EVENT
 
 
 class MockLambdaContext:
@@ -739,3 +740,106 @@ class TestAwsLambdaInstrumentorMocks(TestAwsLambdaInstrumentorBase):
         self.assertEqual(event.name, "exception")
 
         exc_env_patch.stop()
+
+    def test_step_functions_event_sets_attributes(self):
+        """Test Step Functions event creates spans with correct attributes"""
+        AwsLambdaInstrumentor().instrument()
+
+        mock_execute_lambda(MOCK_LAMBDA_STEP_FUNCTIONS_EVENT)
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 4)  # Coralogix creates 4 spans: early trigger, early invocation, final invocation, final trigger
+
+        # Find the Step Functions trigger span (should be the one with Step Functions attributes)
+        step_functions_span = None
+        lambda_span = None
+        
+        for span in spans:
+            if span.attributes.get("faas.trigger") == "stepfunctions":
+                step_functions_span = span
+            else:
+                lambda_span = span
+
+        # Verify Step Functions trigger span
+        self.assertIsNotNone(step_functions_span, "Step Functions trigger span not found")
+        self.assertEqual(step_functions_span.kind, SpanKind.SERVER)
+        self.assertSpanHasAttributes(
+            step_functions_span,
+            {
+                SpanAttributes.FAAS_TRIGGER: "stepfunctions",
+                "faas.trigger.type": "Step Functions",
+                "aws.stepfunctions.execution.arn": "arn:aws:states:us-east-1:123456789012:execution:TestStateMachine:test-execution-123",
+                "aws.stepfunctions.execution.name": "test-execution-123",
+                "aws.stepfunctions.execution.type": "execution",
+                "aws.stepfunctions.role.arn": "arn:aws:iam::123456789012:role/StepFunctionsExecutionRole",
+                "aws.stepfunctions.execution.start_time": "2025-10-15T08:30:00.000Z",
+                "aws.stepfunctions.execution.redrive_count": 0,
+                "aws.stepfunctions.state.name": "InvokeLambda",
+                "aws.stepfunctions.state.entered_time": "2025-10-15T08:30:00.000Z",
+                "aws.stepfunctions.state.retry_count": 0,
+                "aws.stepfunctions.state_machine.arn": "arn:aws:states:us-east-1:123456789012:stateMachine:TestStateMachine",
+                "aws.stepfunctions.state_machine.name": "TestStateMachine",
+            },
+        )
+
+        # Verify Lambda handler span
+        self.assertIsNotNone(lambda_span, "Lambda handler span not found")
+        self.assertEqual(lambda_span.kind, SpanKind.SERVER)
+        self.assertSpanHasAttributes(
+            lambda_span,
+            MOCK_LAMBDA_CONTEXT_ATTRIBUTES,
+        )
+
+    def test_step_functions_event_invalid_context(self):
+        """Test Step Functions event with invalid context creates regular Lambda span"""
+        AwsLambdaInstrumentor().instrument()
+
+        # Mock Step Functions event with missing required fields
+        invalid_step_functions_event = {
+            "executionContext": {
+                "Id": "arn:aws:states:us-east-1:123456789012:execution:TestStateMachine:test-execution-123",
+                # Missing Name, RoleArn, StartTime
+            },
+            "stateContext": {
+                "Name": "InvokeLambda",
+                # Missing EnteredTime, RetryCount
+            },
+            "stateMachineContext": {
+                "Id": "arn:aws:states:us-east-1:123456789012:stateMachine:TestStateMachine",
+                # Missing Name
+            }
+        }
+
+        mock_execute_lambda(invalid_step_functions_event)
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 2)  # Still creates 2 spans (invocation + early invocation)
+
+        # Should not have Step Functions trigger span, only regular Lambda spans
+        for span in spans:
+            self.assertNotEqual(span.attributes.get("faas.trigger"), "stepfunctions")
+
+    def test_step_functions_event_partial_context(self):
+        """Test Step Functions event with partial context creates regular Lambda span"""
+        AwsLambdaInstrumentor().instrument()
+
+        # Mock Step Functions event with only executionContext
+        partial_step_functions_event = {
+            "executionContext": {
+                "Id": "arn:aws:states:us-east-1:123456789012:execution:TestStateMachine:test-execution-123",
+                "Name": "test-execution-123",
+                "RoleArn": "arn:aws:iam::123456789012:role/StepFunctionsExecutionRole",
+                "StartTime": "2025-10-15T08:30:00.000Z",
+                "RedriveCount": 0
+            }
+            # Missing stateContext and stateMachineContext
+        }
+
+        mock_execute_lambda(partial_step_functions_event)
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 2)  # Still creates 2 spans (invocation + early invocation)
+
+        # Should not have Step Functions trigger span, only regular Lambda spans
+        for span in spans:
+            self.assertNotEqual(span.attributes.get("faas.trigger"), "stepfunctions")


### PR DESCRIPTION
# Description

This PR adds AWS Step Functions support to the Coralogix AWS Lambda instrumentation, enabling automatic tracing of Step Functions executions with proper span attributes and context. This addresses the gap in Step Functions observability for Python Lambda functions using Coralogix layers.
The implementation includes:
New StepFunctionsSpan class to detect and process Step Functions events.
Step Functions-specific attributes for comprehensive tracing.
This change enables Step Functions tracing in Coralogix Python layers, providing the same functionality as the existing Node.js implementation.

## Type of change

Please delete options that are not relevant.

- [ x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Deployed to AWS and tested.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x ] Followed the style guidelines of this project
- [x ] Changelogs have been updated
- [ x] Unit tests have been added
- [ ] Documentation has been updated
