### PR TITLE
CX-25550: Avoid 'Attempting to instrument while already instrumented' warning message

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-aws-lambda/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-aws-lambda/pyproject.toml
@@ -34,8 +34,11 @@ dependencies = [
 [project.optional-dependencies]
 instruments = []
 
-[project.entry-points.opentelemetry_instrumentor]
-aws-lambda = "opentelemetry.instrumentation.aws_lambda:AwsLambdaInstrumentor"
+# This will add the AWS package to the loader. But, in Coralogix, we call the
+# instrumentation directly from our wrapper. We remove it from here to avoid warning
+# messages about injecting the instrumentation twice
+# [project.entry-points.opentelemetry_instrumentor]
+# aws-lambda = "opentelemetry.instrumentation.aws_lambda:AwsLambdaInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-aws-lambda"


### PR DESCRIPTION
This avoids trying to inject the instrumentation twice.

Until now, we were injecting via loader and our wrapper. Now, we only use our wrapper.